### PR TITLE
Make top left logo of main screen configurable

### DIFF
--- a/config/opensearch_dashboards.yml
+++ b/config/opensearch_dashboards.yml
@@ -150,3 +150,7 @@
 #  'ff00::/8',
 # ]
 #vis_type_timeline.graphiteBlockedIPs: []
+
+# user input URL for customized logo 
+# opensearchDashboards.branding.logoUrl: ""
+

--- a/src/core/public/chrome/chrome_service.tsx
+++ b/src/core/public/chrome/chrome_service.tsx
@@ -253,6 +253,7 @@ export class ChromeService {
           navControlsRight$={navControls.getRight$()}
           onIsLockedUpdate={setIsNavDrawerLocked}
           isLocked$={getIsNavDrawerLocked$}
+          branding={injectedMetadata.getBranding()}
         />
       ),
 

--- a/src/core/public/chrome/ui/header/__snapshots__/header.test.tsx.snap
+++ b/src/core/public/chrome/ui/header/__snapshots__/header.test.tsx.snap
@@ -247,6 +247,11 @@ exports[`Header renders 1`] = `
       "serverBasePath": "/test",
     }
   }
+  branding={
+    Object {
+      "logoUrl": "/",
+    }
+  }
   breadcrumbs$={
     BehaviorSubject {
       "_isScalar": false,
@@ -1715,6 +1720,7 @@ exports[`Header renders 1`] = `
                     }
                   }
                   href="/"
+                  logoUrl="/"
                   navLinks$={
                     BehaviorSubject {
                       "_isScalar": false,
@@ -2821,6 +2827,7 @@ exports[`Header renders 1`] = `
                       }
                     }
                     href="/"
+                    logoUrl="/"
                     navLinks$={
                       BehaviorSubject {
                         "_isScalar": false,
@@ -2916,36 +2923,24 @@ exports[`Header renders 1`] = `
                     }
                     navigateToApp={[MockFunction]}
                   >
-                    <EuiHeaderLogo
+                    <a
                       aria-label="Go to home page"
+                      className="logoContainer"
                       data-test-subj="logo"
                       href="/"
-                      iconType={[Function]}
                       onClick={[Function]}
                     >
-                      <a
-                        aria-label="Go to home page"
-                        className="euiHeaderLogo"
-                        data-test-subj="logo"
-                        href="/"
-                        onClick={[Function]}
-                        rel="noreferrer"
+                      <CustomLogo
+                        logoUrl="/"
                       >
-                        <EuiIcon
-                          aria-label="Elastic"
-                          className="euiHeaderLogo__icon"
-                          size="l"
-                          type={[Function]}
-                        >
-                          <div
-                            aria-label="Elastic"
-                            className="euiHeaderLogo__icon"
-                            data-euiicon-type="OpenSearchDashboardsLogoDarkMode"
-                            size="l"
-                          />
-                        </EuiIcon>
-                      </a>
-                    </EuiHeaderLogo>
+                        <img
+                          alt="logo"
+                          className="logoImage"
+                          loading="lazy"
+                          src="/"
+                        />
+                      </CustomLogo>
+                    </a>
                   </HeaderLogo>
                 </div>
               </EuiHeaderSectionItem>

--- a/src/core/public/chrome/ui/header/branding/__snapshots__/opensearch_dashboards_custom_logo.test.tsx.snap
+++ b/src/core/public/chrome/ui/header/branding/__snapshots__/opensearch_dashboards_custom_logo.test.tsx.snap
@@ -1,0 +1,117 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Custom Logo Take in a normal URL string 1`] = `
+<CustomLogo
+  className=""
+  intl={
+    Object {
+      "defaultFormats": Object {},
+      "defaultLocale": "en",
+      "formatDate": [Function],
+      "formatHTMLMessage": [Function],
+      "formatMessage": [Function],
+      "formatNumber": [Function],
+      "formatPlural": [Function],
+      "formatRelative": [Function],
+      "formatTime": [Function],
+      "formats": Object {
+        "date": Object {
+          "full": Object {
+            "day": "numeric",
+            "month": "long",
+            "weekday": "long",
+            "year": "numeric",
+          },
+          "long": Object {
+            "day": "numeric",
+            "month": "long",
+            "year": "numeric",
+          },
+          "medium": Object {
+            "day": "numeric",
+            "month": "short",
+            "year": "numeric",
+          },
+          "short": Object {
+            "day": "numeric",
+            "month": "numeric",
+            "year": "2-digit",
+          },
+        },
+        "number": Object {
+          "currency": Object {
+            "style": "currency",
+          },
+          "percent": Object {
+            "style": "percent",
+          },
+        },
+        "relative": Object {
+          "days": Object {
+            "units": "day",
+          },
+          "hours": Object {
+            "units": "hour",
+          },
+          "minutes": Object {
+            "units": "minute",
+          },
+          "months": Object {
+            "units": "month",
+          },
+          "seconds": Object {
+            "units": "second",
+          },
+          "years": Object {
+            "units": "year",
+          },
+        },
+        "time": Object {
+          "full": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+            "second": "numeric",
+            "timeZoneName": "short",
+          },
+          "long": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+            "second": "numeric",
+            "timeZoneName": "short",
+          },
+          "medium": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+            "second": "numeric",
+          },
+          "short": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+          },
+        },
+      },
+      "formatters": Object {
+        "getDateTimeFormat": [Function],
+        "getMessageFormat": [Function],
+        "getNumberFormat": [Function],
+        "getPluralFormat": [Function],
+        "getRelativeFormat": [Function],
+      },
+      "locale": "en",
+      "messages": Object {},
+      "now": [Function],
+      "onError": [Function],
+      "textComponent": Symbol(react.fragment),
+      "timeZone": null,
+    }
+  }
+  logoUrl="/"
+>
+  <img
+    alt="logo"
+    className="logoImage"
+    loading="lazy"
+    src="/"
+  />
+</CustomLogo>
+`;

--- a/src/core/public/chrome/ui/header/branding/opensearch_dashboards_custom_logo.test.tsx
+++ b/src/core/public/chrome/ui/header/branding/opensearch_dashboards_custom_logo.test.tsx
@@ -1,0 +1,19 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+import React from 'react';
+import { mountWithIntl } from 'test_utils/enzyme_helpers';
+import { CustomLogo } from './opensearch_dashboards_custom_logo';
+
+describe('Custom Logo', () => {
+  it('Take in a normal URL string', () => {
+    const branding = { logoUrl: '/', className: '' };
+    const component = mountWithIntl(<CustomLogo {...branding} />);
+    expect(component).toMatchSnapshot();
+  });
+});

--- a/src/core/public/chrome/ui/header/branding/opensearch_dashboards_custom_logo.tsx
+++ b/src/core/public/chrome/ui/header/branding/opensearch_dashboards_custom_logo.tsx
@@ -29,24 +29,23 @@
  * Modifications Copyright OpenSearch Contributors. See
  * GitHub history for details.
  */
-import type { PublicMethodsOf } from '@osd/utility-types';
-import { RenderingService as Service } from '../rendering_service';
-import { InternalRenderingServiceSetup } from '../types';
-import { mockRenderingServiceParams } from './params';
 
-type IRenderingService = PublicMethodsOf<Service>;
+import React from 'react';
+import '../header_logo.scss';
 
-export const setupMock: jest.Mocked<InternalRenderingServiceSetup> = {
-  render: jest.fn(),
+export interface CustomLogoType {
+  logoUrl: string;
+}
+
+export const CustomLogo = ({ ...branding }: CustomLogoType) => {
+  return (
+    <img
+      data-test-subj="customLogo"
+      data-test-image-url={branding.logoUrl}
+      src={branding.logoUrl}
+      alt="logo"
+      loading="lazy"
+      className="logoImage"
+    />
+  );
 };
-export const mockSetup = jest.fn().mockResolvedValue(setupMock);
-export const mockStop = jest.fn();
-export const mockCheckUrlValid = jest.fn();
-export const mockRenderingService: jest.Mocked<IRenderingService> = {
-  setup: mockSetup,
-  stop: mockStop,
-  checkUrlValid: mockCheckUrlValid,
-};
-export const RenderingService = jest.fn<IRenderingService, [typeof mockRenderingServiceParams]>(
-  () => mockRenderingService
-);

--- a/src/core/public/chrome/ui/header/header.test.tsx
+++ b/src/core/public/chrome/ui/header/header.test.tsx
@@ -69,6 +69,7 @@ function mockProps() {
     isLocked$: new BehaviorSubject(false),
     loadingCount$: new BehaviorSubject(0),
     onIsLockedUpdate: () => {},
+    branding: { logoUrl: '/' },
   };
 }
 

--- a/src/core/public/chrome/ui/header/header.tsx
+++ b/src/core/public/chrome/ui/header/header.tsx
@@ -87,6 +87,7 @@ export interface HeaderProps {
   isLocked$: Observable<boolean>;
   loadingCount$: ReturnType<HttpStart['getLoadingCount$']>;
   onIsLockedUpdate: OnIsLockedUpdate;
+  branding: { logoUrl: string };
 }
 
 export function Header({
@@ -96,6 +97,7 @@ export function Header({
   basePath,
   onIsLockedUpdate,
   homeHref,
+  branding,
   ...observables
 }: HeaderProps) {
   const isVisible = useObservable(observables.isVisible$, false);
@@ -125,6 +127,7 @@ export function Header({
                     forceNavigation$={observables.forceAppSwitcherNavigation$}
                     navLinks$={observables.navLinks$}
                     navigateToApp={application.navigateToApp}
+                    logoUrl={branding.logoUrl}
                   />,
                   <LoadingIndicator loadingCount$={observables.loadingCount$} />,
                 ],

--- a/src/core/public/chrome/ui/header/header_logo.scss
+++ b/src/core/public/chrome/ui/header/header_logo.scss
@@ -1,0 +1,9 @@
+.logoContainer {
+    height: 30px;
+    padding: 3px 3px 3px 10px;
+}
+
+.logoImage{
+    height: 100%;
+    max-width: 100%;
+}

--- a/src/core/public/chrome/ui/header/header_logo.tsx
+++ b/src/core/public/chrome/ui/header/header_logo.tsx
@@ -30,14 +30,14 @@
  * GitHub history for details.
  */
 
-import { EuiHeaderLogo } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
 import React from 'react';
 import useObservable from 'react-use/lib/useObservable';
 import { Observable } from 'rxjs';
 import Url from 'url';
 import { ChromeNavLink } from '../..';
-import { OpenSearchDashboardsLogoDarkMode } from './branding/opensearch_dashboards_logo_darkmode';
+import { CustomLogo, CustomLogoType } from './branding/opensearch_dashboards_custom_logo';
+import './header_logo.scss';
 
 function findClosestAnchor(element: HTMLElement): HTMLAnchorElement | void {
   let current = element;
@@ -104,21 +104,27 @@ interface Props {
   navLinks$: Observable<ChromeNavLink[]>;
   forceNavigation$: Observable<boolean>;
   navigateToApp: (appId: string) => void;
+  logoUrl: string;
 }
 
-export function HeaderLogo({ href, navigateToApp, ...observables }: Props) {
+export function HeaderLogo({ href, navigateToApp, logoUrl, ...observables }: Props) {
   const forceNavigation = useObservable(observables.forceNavigation$, false);
   const navLinks = useObservable(observables.navLinks$, []);
+  const branding: CustomLogoType = {
+    logoUrl,
+  };
 
   return (
-    <EuiHeaderLogo
+    <a
       data-test-subj="logo"
-      iconType={OpenSearchDashboardsLogoDarkMode}
       onClick={(e) => onClick(e, forceNavigation, navLinks, navigateToApp)}
       href={href}
       aria-label={i18n.translate('core.ui.chrome.headerGlobalNav.goHomePageIconAriaLabel', {
         defaultMessage: 'Go to home page',
       })}
-    />
+      className="logoContainer"
+    >
+      <CustomLogo {...branding} />
+    </a>
   );
 }

--- a/src/core/public/injected_metadata/injected_metadata_service.mock.ts
+++ b/src/core/public/injected_metadata/injected_metadata_service.mock.ts
@@ -45,6 +45,7 @@ const createSetupContractMock = () => {
     getInjectedVar: jest.fn(),
     getInjectedVars: jest.fn(),
     getOpenSearchDashboardsBuildNumber: jest.fn(),
+    getBranding: jest.fn(),
   };
   setupContract.getCspConfig.mockReturnValue({ warnLegacyBrowsers: true });
   setupContract.getOpenSearchDashboardsVersion.mockReturnValue('opensearchDashboardsVersion');

--- a/src/core/public/injected_metadata/injected_metadata_service.test.ts
+++ b/src/core/public/injected_metadata/injected_metadata_service.test.ts
@@ -229,3 +229,16 @@ describe('setup.getInjectedVars()', () => {
     );
   });
 });
+
+describe('setup.getBranding()', () => {
+  it('returns injectedMetadata.branding', () => {
+    const injectedMetadata = new InjectedMetadataService({
+      injectedMetadata: {
+        branding: { logoUrl: '/' },
+      },
+    } as any);
+
+    const logoURL = injectedMetadata.setup().getBranding();
+    expect(logoURL).toEqual({ logoUrl: '/' });
+  });
+});

--- a/src/core/public/injected_metadata/injected_metadata_service.ts
+++ b/src/core/public/injected_metadata/injected_metadata_service.ts
@@ -76,6 +76,9 @@ export interface InjectedMetadataParams {
         user?: Record<string, UserProvidedValues>;
       };
     };
+    branding: {
+      logoUrl: string;
+    };
   };
 }
 
@@ -143,6 +146,10 @@ export class InjectedMetadataService {
       getOpenSearchDashboardsBranch: () => {
         return this.state.branch;
       },
+
+      getBranding: () => {
+        return this.state.branding;
+      },
     };
   }
 }
@@ -175,6 +182,9 @@ export interface InjectedMetadataSetup {
   getInjectedVar: (name: string, defaultValue?: any) => unknown;
   getInjectedVars: () => {
     [key: string]: unknown;
+  };
+  getBranding: () => {
+    logoUrl: string;
   };
 }
 

--- a/src/core/server/opensearch_dashboards_config.ts
+++ b/src/core/server/opensearch_dashboards_config.ts
@@ -52,6 +52,12 @@ export const config = {
     index: schema.string({ defaultValue: '.kibana' }),
     autocompleteTerminateAfter: schema.duration({ defaultValue: 100000 }),
     autocompleteTimeout: schema.duration({ defaultValue: 1000 }),
+    branding: schema.object({
+      logoUrl: schema.string({
+        defaultValue:
+          'https://opensearch.org/assets/brand/SVG/Logo/opensearch_dashboards_logo_darkmode.svg',
+      }),
+    }),
   }),
   deprecations,
 };

--- a/src/core/server/rendering/__snapshots__/rendering_service.test.ts.snap
+++ b/src/core/server/rendering/__snapshots__/rendering_service.test.ts.snap
@@ -5,6 +5,9 @@ Object {
   "anonymousStatusPage": false,
   "basePath": "/mock-server-basepath",
   "branch": Any<String>,
+  "branding": Object {
+    "logoUrl": "https://opensearch.org/assets/brand/SVG/Logo/opensearch_dashboards_logo_darkmode.svg",
+  },
   "buildNumber": Any<Number>,
   "csp": Object {
     "warnLegacyBrowsers": true,
@@ -48,6 +51,9 @@ Object {
   "anonymousStatusPage": false,
   "basePath": "/mock-server-basepath",
   "branch": Any<String>,
+  "branding": Object {
+    "logoUrl": "https://opensearch.org/assets/brand/SVG/Logo/opensearch_dashboards_logo_darkmode.svg",
+  },
   "buildNumber": Any<Number>,
   "csp": Object {
     "warnLegacyBrowsers": true,
@@ -91,6 +97,9 @@ Object {
   "anonymousStatusPage": false,
   "basePath": "/mock-server-basepath",
   "branch": Any<String>,
+  "branding": Object {
+    "logoUrl": "https://opensearch.org/assets/brand/SVG/Logo/opensearch_dashboards_logo_darkmode.svg",
+  },
   "buildNumber": Any<Number>,
   "csp": Object {
     "warnLegacyBrowsers": true,
@@ -138,6 +147,9 @@ Object {
   "anonymousStatusPage": false,
   "basePath": "",
   "branch": Any<String>,
+  "branding": Object {
+    "logoUrl": "https://opensearch.org/assets/brand/SVG/Logo/opensearch_dashboards_logo_darkmode.svg",
+  },
   "buildNumber": Any<Number>,
   "csp": Object {
     "warnLegacyBrowsers": true,
@@ -181,6 +193,9 @@ Object {
   "anonymousStatusPage": false,
   "basePath": "/mock-server-basepath",
   "branch": Any<String>,
+  "branding": Object {
+    "logoUrl": "https://opensearch.org/assets/brand/SVG/Logo/opensearch_dashboards_logo_darkmode.svg",
+  },
   "buildNumber": Any<Number>,
   "csp": Object {
     "warnLegacyBrowsers": true,

--- a/src/core/server/rendering/types.ts
+++ b/src/core/server/rendering/types.ts
@@ -74,6 +74,9 @@ export interface RenderingMetadata {
         user: Record<string, UserProvidedValues<any>>;
       };
     };
+    branding: {
+      logoUrl: string;
+    };
   };
 }
 

--- a/src/legacy/server/config/schema.js
+++ b/src/legacy/server/config/schema.js
@@ -233,6 +233,11 @@ export default () =>
       autocompleteTerminateAfter: Joi.number().integer().min(1).default(100000),
       // TODO Also allow units here like in opensearch config once this is moved to the new platform
       autocompleteTimeout: Joi.number().integer().min(1).default(1000),
+      branding: Joi.object({
+        logoUrl: Joi.string().default(
+          'https://opensearch.org/assets/brand/SVG/Logo/opensearch_dashboards_logo_darkmode.svg'
+        ),
+      }),
     }).default(),
 
     savedObjects: HANDLED_IN_NEW_PLATFORM,

--- a/test/common/config.js
+++ b/test/common/config.js
@@ -74,6 +74,8 @@ export default function () {
         // `--plugin-path=${path.join(__dirname, 'fixtures', 'plugins', 'newsfeed')}`,
         // `--newsfeed.service.urlRoot=${servers.opensearchDashboards.protocol}://${servers.opensearchDashboards.hostname}:${servers.opensearchDashboards.port}`,
         // `--newsfeed.service.pathTemplate=/api/_newsfeed-FTS-external-service-simulators/opensearch-dashboards/v{VERSION}.json`,
+        // Custom branding config
+        `--opensearchDashboards.branding.logoUrl=https://opensearch.org/assets/brand/SVG/Logo/opensearch_logo_darkmode.svg`,
       ],
     },
     services,

--- a/test/functional/apps/visualize/_custom_branding.js
+++ b/test/functional/apps/visualize/_custom_branding.js
@@ -29,24 +29,30 @@
  * Modifications Copyright OpenSearch Contributors. See
  * GitHub history for details.
  */
-import type { PublicMethodsOf } from '@osd/utility-types';
-import { RenderingService as Service } from '../rendering_service';
-import { InternalRenderingServiceSetup } from '../types';
-import { mockRenderingServiceParams } from './params';
+import expect from '@osd/expect';
 
-type IRenderingService = PublicMethodsOf<Service>;
+export default function ({ getService, getPageObjects }) {
+  const browser = getService('browser');
+  const globalNav = getService('globalNav');
+  const PageObjects = getPageObjects(['common', 'home', 'header']);
 
-export const setupMock: jest.Mocked<InternalRenderingServiceSetup> = {
-  render: jest.fn(),
-};
-export const mockSetup = jest.fn().mockResolvedValue(setupMock);
-export const mockStop = jest.fn();
-export const mockCheckUrlValid = jest.fn();
-export const mockRenderingService: jest.Mocked<IRenderingService> = {
-  setup: mockSetup,
-  stop: mockStop,
-  checkUrlValid: mockCheckUrlValid,
-};
-export const RenderingService = jest.fn<IRenderingService, [typeof mockRenderingServiceParams]>(
-  () => mockRenderingService
-);
+  describe('OpenSearch Dashboards branding configuration', function customLogo() {
+    this.tags('includeFirefox');
+    const expectedUrl = 'https://opensearch.org/assets/brand/SVG/Logo/opensearch_logo_darkmode.svg';
+    before(async function () {
+      await PageObjects.common.navigateToApp('home');
+    });
+
+    it('should show customized logo in Navbar on the main page', async () => {
+      await globalNav.logoExistsOrFail(expectedUrl);
+    });
+
+    it('should show a customized logo that can take to home page', async () => {
+      await PageObjects.common.navigateToApp('settings');
+      await globalNav.clickLogo();
+      await PageObjects.header.waitUntilLoadingHasFinished();
+      const url = await browser.getCurrentUrl();
+      expect(url.includes('/app/home')).to.be(true);
+    });
+  });
+}

--- a/test/functional/apps/visualize/index.ts
+++ b/test/functional/apps/visualize/index.ts
@@ -58,6 +58,7 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
     describe('', function () {
       this.tags('ciGroup9');
 
+      loadTestFile(require.resolve('./_custom_branding'));
       loadTestFile(require.resolve('./_embedding_chart'));
       loadTestFile(require.resolve('./_chart_types'));
       loadTestFile(require.resolve('./_area_chart'));

--- a/test/functional/services/global_nav.ts
+++ b/test/functional/services/global_nav.ts
@@ -74,6 +74,15 @@ export function GlobalNavProvider({ getService }: FtrProviderContext) {
     public async badgeMissingOrFail(): Promise<void> {
       await testSubjects.missingOrFail('headerBadge');
     }
+
+    public async logoExistsOrFail(expectedUrl: string): Promise<void> {
+      await testSubjects.exists('headerGlobalNav > logo > customLogo');
+      const actualLabel = await testSubjects.getAttribute(
+        'headerGlobalNav > logo > customLogo',
+        'data-test-image-url'
+      );
+      expect(actualLabel.toUpperCase()).to.equal(expectedUrl.toUpperCase());
+    }
   }
 
   return new GlobalNav();


### PR DESCRIPTION
### Description
US1: User can set logo in the opensearch_dashboards.yml and see it in the application at run time in the top left corner of the main screen. 

### Requirement:
User need to input a valid URL for opensearchDashboards.branding.logoUrl in the opensearch_dashboards.yml file. 
![image](https://user-images.githubusercontent.com/43937633/130196207-953e1036-924d-426f-a65b-dc0ad32b2a7d.png)

### Details:
* If the URL is invalid or does not end with jpeg, jpg, gif, png, svg, the default OpenSearch Dashboard logo will be shown. An application error log will be shown.
* User can input URL with image of any size, and the image will be formatted to a fixed size.
* User needs to be responsible for the content of the URL.
* This is a local setting; user needs to set this config in all nodes in OpenSearch Dashboards if a global setting is wanted.

### Related Project Card:
https://github.com/abbyhu2000/OpenSearch-Dashboards/projects/1#card-67164500

Signed-off-by: Abby Hu <abigailhu2000@gmail.com>

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 