### PR TITLE
[Draft] Implementing a new branding service

### DIFF
--- a/config/opensearch_dashboards.yml
+++ b/config/opensearch_dashboards.yml
@@ -163,16 +163,16 @@
 # ]
 #vis_type_timeline.graphiteBlockedIPs: []
 
-# opensearchDashboards.branding:
-#   logo:
-#     defaultUrl: ""
-#     darkModeUrl: ""
-#   mark:
-#     defaultUrl: ""
-#     darkModeUrl: ""
-#   loadingLogo:
-#     defaultUrl: ""
-#     darkModeUrl: ""
+ opensearchDashboards.branding:
+   logo:
+     defaultUrl: "https://clipground.com/images/aws-logo-png-9.png"
+     darkModeUrl: "https://vectorified.com/image/aws-logo-vector-5.png"
+   mark:
+     defaultUrl: "https://pngimage.net/wp-content/uploads/2020/02/aws-logo-png-4.png"
+     darkModeUrl: "https://abacusinsights.com/wp-content/uploads/2019/07/logo-AWS.png"
+   loadingLogo:
+     defaultUrl: "https://mir-s3-cdn-cf.behance.net/project_modules/max_1200/d31fcf75226323.5c4702fb7ef89.gif"
+     darkModeUrl: "https://gifimage.net/wp-content/uploads/2018/05/sparkler-gif-9.gif"
 #   faviconUrl: ""
 #   applicationTitle: ""
 #   useExpandedHeader: false

--- a/src/core/public/chrome/chrome_service.tsx
+++ b/src/core/public/chrome/chrome_service.tsx
@@ -40,6 +40,7 @@ import { InternalApplicationStart } from '../application';
 import { DocLinksStart } from '../doc_links';
 import { HttpStart } from '../http';
 import { InjectedMetadataStart } from '../injected_metadata';
+import { InjectedBrandingStart } from '../injected_branding';
 import { NotificationsStart } from '../notifications';
 import { IUiSettingsClient } from '../ui_settings';
 import { OPENSEARCH_DASHBOARDS_ASK_OPENSEARCH_LINK } from './constants';
@@ -98,6 +99,7 @@ interface StartDeps {
   docLinks: DocLinksStart;
   http: HttpStart;
   injectedMetadata: InjectedMetadataStart;
+  injectedBranding: InjectedBrandingStart;
   notifications: NotificationsStart;
   uiSettings: IUiSettingsClient;
 }
@@ -151,6 +153,7 @@ export class ChromeService {
     docLinks,
     http,
     injectedMetadata,
+    injectedBranding,
     notifications,
     uiSettings,
   }: StartDeps): Promise<InternalChromeStart> {
@@ -261,7 +264,7 @@ export class ChromeService {
           navControlsExpandedRight$={navControls.getExpandedRight$()}
           onIsLockedUpdate={setIsNavDrawerLocked}
           isLocked$={getIsNavDrawerLocked$}
-          branding={injectedMetadata.getBranding()}
+          branding={injectedBranding.getBranding()}
         />
       ),
 

--- a/src/core/public/chrome/ui/header/collapsible_nav.tsx
+++ b/src/core/public/chrome/ui/header/collapsible_nav.tsx
@@ -142,28 +142,7 @@ export function CollapsibleNav({
   const DARKMODE_OPENSEARCH_MARK = `${branding.assetFolderUrl}/opensearch_mark_dark_mode.svg`;
 
   const darkMode = branding.darkMode;
-  const markDefault = branding.mark?.defaultUrl;
-  const markDarkMode = branding.mark?.darkModeUrl;
-
-  /**
-   * Use branding configurations to check which URL to use for rendering
-   * side menu opensearch logo in default mode
-   *
-   * @returns a valid custom URL or original default mode opensearch mark if no valid URL is provided
-   */
-  const customSideMenuLogoDefaultMode = () => {
-    return markDefault ?? DEFAULT_OPENSEARCH_MARK;
-  };
-
-  /**
-   * Use branding configurations to check which URL to use for rendering
-   * side menu opensearch logo in dark mode
-   *
-   * @returns a valid custom URL or original dark mode opensearch mark if no valid URL is provided
-   */
-  const customSideMenuLogoDarkMode = () => {
-    return markDarkMode ?? markDefault ?? DARKMODE_OPENSEARCH_MARK;
-  };
+  const mark = branding.mark;
 
   /**
    * Render custom side menu logo for both default mode and dark mode
@@ -171,7 +150,7 @@ export function CollapsibleNav({
    * @returns a valid logo URL
    */
   const customSideMenuLogo = () => {
-    return darkMode ? customSideMenuLogoDarkMode() : customSideMenuLogoDefaultMode();
+    return mark ?? (darkMode ? DARKMODE_OPENSEARCH_MARK : DEFAULT_OPENSEARCH_MARK);
   };
 
   return (

--- a/src/core/public/chrome/ui/header/header_logo.tsx
+++ b/src/core/public/chrome/ui/header/header_logo.tsx
@@ -113,16 +113,14 @@ export function HeaderLogo({ href, navigateToApp, branding, ...observables }: Pr
   const {
     darkMode,
     assetFolderUrl = '',
-    logo = {},
+    logo = '',
     applicationTitle = 'opensearch dashboards',
   } = branding;
-  const { defaultUrl: logoUrl, darkModeUrl: darkLogoUrl } = logo;
 
-  const customLogo = darkMode ? darkLogoUrl ?? logoUrl : logoUrl;
   const defaultLogo = darkMode ? DEFAULT_DARK_LOGO : DEFAULT_LOGO;
 
-  const logoSrc = customLogo ? customLogo : `${assetFolderUrl}/${defaultLogo}`;
-  const testSubj = customLogo ? 'customLogo' : 'defaultLogo';
+  const logoSrc = logo ? logo : `${assetFolderUrl}/${defaultLogo}`;
+  const testSubj = logo ? 'customLogo' : 'defaultLogo';
   const alt = `${applicationTitle} logo`;
 
   return (

--- a/src/core/public/chrome/ui/header/home_icon.tsx
+++ b/src/core/public/chrome/ui/header/home_icon.tsx
@@ -23,18 +23,11 @@ export const HomeIcon = ({
   applicationTitle = 'opensearch dashboards',
   useExpandedHeader = true,
 }: ChromeBranding) => {
-  const { defaultUrl: markUrl, darkModeUrl: darkMarkUrl } = mark ?? {};
-
-  const customMark = darkMode ? darkMarkUrl ?? markUrl : markUrl;
   const defaultMark = darkMode ? DEFAULT_DARK_MARK : DEFAULT_MARK;
 
   const getIconProps = () => {
-    const iconType = customMark
-      ? customMark
-      : useExpandedHeader
-      ? 'home'
-      : `${assetFolderUrl}/${defaultMark}`;
-    const testSubj = customMark ? 'customMark' : useExpandedHeader ? 'homeIcon' : 'defaultMark';
+    const iconType = mark ? mark : useExpandedHeader ? 'home' : `${assetFolderUrl}/${defaultMark}`;
+    const testSubj = mark ? 'customMark' : useExpandedHeader ? 'homeIcon' : 'defaultMark';
     const title = `${applicationTitle} home`;
     // marks look better at the large size, but the home icon should be medium to fit in with other icons
     const size = iconType === 'home' ? ('m' as const) : ('l' as const);

--- a/src/core/public/index.ts
+++ b/src/core/public/index.ts
@@ -235,6 +235,8 @@ export interface CoreSetup<TPluginsStart extends object = object, TStart = unkno
    * */
   injectedMetadata: {
     getInjectedVar: (name: string, defaultValue?: any) => unknown;
+  };
+  injectedBranding: {
     getBranding: () => Branding;
   };
   /** {@link StartServicesAccessor} */
@@ -291,6 +293,8 @@ export interface CoreStart {
    * */
   injectedMetadata: {
     getInjectedVar: (name: string, defaultValue?: any) => unknown;
+  };
+  injectedBranding: {
     getBranding: () => Branding;
   };
 }

--- a/src/core/public/injected_branding/index.ts
+++ b/src/core/public/injected_branding/index.ts
@@ -28,29 +28,9 @@
  * under the License.
  */
 
-/**
- * A type definition for custom branding configurations from yml file
- * @public
- */
-
-export interface Branding {
-  /** Default mode or Dark mode*/
-  darkMode?: boolean;
-  /** Relative path to the asset folder */
-  assetFolderUrl?: string;
-  /** Small logo icon that will be used in most logo occurrences */
-  mark?: string;
-  /** Fuller logo that will be rendered on nav bar header */
-  logo?: string;
-  /** Loading logo that will be rendered on the loading page */
-  loadingLogo?: {
-    url?: string;
-    loadBar?: boolean;
-  };
-  /** Custom favicon that will be rendered on the browser tab */
-  faviconUrl?: string;
-  /** Application title that will replace the default opensearch dashboard string */
-  applicationTitle?: string;
-  /** Whether to use expanded menu (true) or condensed menu (false) */
-  useExpandedHeader?: boolean;
-}
+export {
+  InjectedBrandingService,
+  InjectedBrandingParams,
+  InjectedBrandingSetup,
+  InjectedBrandingStart,
+} from './injected_branding_service';

--- a/src/core/public/injected_branding/injected_branding_service.ts
+++ b/src/core/public/injected_branding/injected_branding_service.ts
@@ -28,29 +28,40 @@
  * under the License.
  */
 
-/**
- * A type definition for custom branding configurations from yml file
- * @public
- */
+import { deepFreeze } from '@osd/std';
+import { Branding } from '../';
 
-export interface Branding {
-  /** Default mode or Dark mode*/
-  darkMode?: boolean;
-  /** Relative path to the asset folder */
-  assetFolderUrl?: string;
-  /** Small logo icon that will be used in most logo occurrences */
-  mark?: string;
-  /** Fuller logo that will be rendered on nav bar header */
-  logo?: string;
-  /** Loading logo that will be rendered on the loading page */
-  loadingLogo?: {
-    url?: string;
-    loadBar?: boolean;
-  };
-  /** Custom favicon that will be rendered on the browser tab */
-  faviconUrl?: string;
-  /** Application title that will replace the default opensearch dashboard string */
-  applicationTitle?: string;
-  /** Whether to use expanded menu (true) or condensed menu (false) */
-  useExpandedHeader?: boolean;
+/** @internal */
+export interface InjectedBrandingParams {
+  branding: Branding;
 }
+
+export class InjectedBrandingService {
+  private state = deepFreeze(this.params.branding) as InjectedBrandingParams['branding'];
+
+  constructor(private readonly params: InjectedBrandingParams) {}
+
+  public start(): InjectedBrandingStart {
+    return this.setup();
+  }
+
+  public setup(): InjectedBrandingSetup {
+    return {
+      getBranding: () => {
+        return this.state;
+      },
+    };
+  }
+}
+
+/**
+ * Provides access to the metadata injected by the server into the page
+ *
+ * @internal
+ */
+export interface InjectedBrandingSetup {
+  getBranding: () => Branding;
+}
+
+/** @internal */
+export type InjectedBrandingStart = InjectedBrandingSetup;

--- a/src/core/public/injected_metadata/injected_metadata_service.ts
+++ b/src/core/public/injected_metadata/injected_metadata_service.ts
@@ -37,7 +37,7 @@ import {
   UiSettingsParams,
   UserProvidedValues,
 } from '../../server/types';
-import { AppCategory, Branding } from '../';
+import { AppCategory } from '../';
 
 export interface InjectedPluginMetadata {
   id: PluginName;
@@ -74,7 +74,6 @@ export interface InjectedMetadataParams {
         user?: Record<string, UserProvidedValues>;
       };
     };
-    branding: Branding;
   };
 }
 
@@ -142,10 +141,6 @@ export class InjectedMetadataService {
       getOpenSearchDashboardsBranch: () => {
         return this.state.branch;
       },
-
-      getBranding: () => {
-        return this.state.branding;
-      },
     };
   }
 }
@@ -179,7 +174,6 @@ export interface InjectedMetadataSetup {
   getInjectedVars: () => {
     [key: string]: unknown;
   };
-  getBranding: () => Branding;
 }
 
 /** @internal */

--- a/src/core/public/mocks.ts
+++ b/src/core/public/mocks.ts
@@ -102,7 +102,6 @@ function createCoreStartMock({ basePath = '' } = {}) {
     savedObjects: savedObjectsServiceMock.createStartContract(),
     injectedMetadata: {
       getInjectedVar: injectedMetadataServiceMock.createStartContract().getInjectedVar,
-      getBranding: injectedMetadataServiceMock.createStartContract().getBranding,
     },
     fatalErrors: fatalErrorsServiceMock.createStartContract(),
   };

--- a/src/core/public/osd_bootstrap.ts
+++ b/src/core/public/osd_bootstrap.ts
@@ -38,6 +38,8 @@ export async function __osdBootstrap__() {
     document.querySelector('osd-injected-metadata')!.getAttribute('data')!
   );
 
+  const branding = JSON.parse(document.querySelector('osd-branding')!.getAttribute('data')!);
+
   let i18nError: Error | undefined;
   const apmSystem = new ApmSystem(injectedMetadata.vars.apmConfig, injectedMetadata.basePath);
 
@@ -51,6 +53,7 @@ export async function __osdBootstrap__() {
 
   const coreSystem = new CoreSystem({
     injectedMetadata,
+    branding,
     rootDomElement: document.body,
     browserSupportsCsp: !(window as any).__osdCspNotEnforced__,
   });

--- a/src/core/public/plugins/plugin_context.ts
+++ b/src/core/public/plugins/plugin_context.ts
@@ -118,7 +118,9 @@ export function createPluginSetupContext<
     uiSettings: deps.uiSettings,
     injectedMetadata: {
       getInjectedVar: deps.injectedMetadata.getInjectedVar,
-      getBranding: deps.injectedMetadata.getBranding,
+    },
+    injectedBranding: {
+      getBranding: deps.injectedBranding.getBranding,
     },
     getStartServices: () => plugin.startDependencies,
   };
@@ -165,7 +167,9 @@ export function createPluginStartContext<
     savedObjects: deps.savedObjects,
     injectedMetadata: {
       getInjectedVar: deps.injectedMetadata.getInjectedVar,
-      getBranding: deps.injectedMetadata.getBranding,
+    },
+    injectedBranding: {
+      getBranding: deps.injectedBranding.getBranding,
     },
     fatalErrors: deps.fatalErrors,
   };

--- a/src/core/server/branding_service/branding_service.tsx
+++ b/src/core/server/branding_service/branding_service.tsx
@@ -1,0 +1,382 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React from 'react';
+import { first, take } from 'rxjs/operators';
+import { Agent as HttpsAgent } from 'https';
+import { Branding } from 'src/core/types';
+import Axios from 'axios';
+// @ts-expect-error untyped internal module used to prevent axios from using xhr adapter in tests
+import AxiosHttpAdapter from 'axios/lib/adapters/http';
+import { CoreContext } from '../core_context';
+import { BrandingValidation, BrandingAssignment } from './types';
+import { OpenSearchDashboardsConfigType } from '../opensearch_dashboards_config';
+import { HttpConfigType } from '../http/http_config';
+import { SslConfig } from '../http/ssl_config';
+import { LoggerFactory } from '../logging';
+
+const DEFAULT_TITLE = 'OpenSearch Dashboards';
+
+/** @internal */
+export class BrandingService {
+  constructor(private readonly coreContext: CoreContext) {
+    this.logger = this.coreContext.logger;
+  }
+  private logger: LoggerFactory;
+  private httpsAgent?: HttpsAgent;
+
+  public async setup(darkMode: boolean, uiPublicUrl: string) {
+    const [opensearchDashboardsConfig, serverConfig] = await Promise.all([
+      this.coreContext.configService
+        .atPath<OpenSearchDashboardsConfigType>('opensearchDashboards')
+        .pipe(first())
+        .toPromise(),
+      this.coreContext.configService.atPath<HttpConfigType>('server').pipe(first()).toPromise(),
+    ]);
+
+    this.setupHttpAgent(serverConfig as HttpConfigType);
+
+    const brandingAssignment = await this.assignBrandingConfig(
+      darkMode,
+      opensearchDashboardsConfig as OpenSearchDashboardsConfigType
+    );
+
+    const brandingData: Branding = {
+      darkMode,
+      assetFolderUrl: `${uiPublicUrl}/default_branding`,
+      logo: this.darkModeLogic(
+        darkMode,
+        brandingAssignment.logoDefault,
+        brandingAssignment.logoDarkmode
+      ),
+
+      mark: this.darkModeLogic(
+        darkMode,
+        brandingAssignment.markDefault,
+        brandingAssignment.markDarkmode
+      ),
+      loadingLogo: {
+        url: this.loadingLogoLogic(darkMode, brandingAssignment).loadinglogo,
+        loadBar: this.loadingLogoLogic(darkMode, brandingAssignment).loadBar,
+      },
+      faviconUrl: brandingAssignment.favicon,
+      applicationTitle: brandingAssignment.applicationTitle,
+      useExpandedHeader: brandingAssignment.useExpandedHeader,
+    };
+
+    return brandingData;
+  }
+
+  public async stop() {}
+
+  private darkModeLogic(darkMode: boolean, defaultUrl?: string, darkmodeUrl?: string) {
+    const defaultImg = defaultUrl ?? undefined;
+    const darkImg = darkmodeUrl ?? defaultUrl ?? undefined;
+    return darkMode ? darkImg : defaultImg;
+  }
+
+  private loadingLogoLogic(
+    darkMode: boolean,
+    { markDefault, markDarkmode, loadingLogoDefault, loadingLogoDarkmode }: BrandingAssignment
+  ) {
+    const defaultLoading = loadingLogoDefault ?? markDefault ?? undefined;
+    const darkLoading =
+      loadingLogoDarkmode ?? loadingLogoDefault ?? markDarkmode ?? markDefault ?? undefined;
+    const loadinglogo = darkMode ? darkLoading : defaultLoading;
+    const loadBar = !loadingLogoDefault && defaultLoading ? true : false;
+    return { loadinglogo, loadBar };
+  }
+
+  /**
+   * Setups HTTP Agent if SSL is enabled to pass SSL config
+   * values to Axios to make requests in while validating
+   * resources.
+   *
+   * @param {Readonly<HttpConfigType>} httpConfig
+   */
+  private setupHttpAgent(httpConfig: Readonly<HttpConfigType>) {
+    if (!httpConfig.ssl?.enabled) return;
+    try {
+      const sslConfig = new SslConfig(httpConfig.ssl);
+      this.httpsAgent = new HttpsAgent({
+        ca: sslConfig.certificateAuthorities,
+        cert: sslConfig.certificate,
+        key: sslConfig.key,
+        passphrase: sslConfig.keyPassphrase,
+        rejectUnauthorized: false,
+      });
+    } catch (e) {
+      this.logger.get('branding').error('HTTP agent failed to setup for SSL.');
+    }
+  }
+
+  /**
+   * Assign values for branding related configurations based on branding validation
+   * by calling checkBrandingValid(). For dark mode URLs, add additonal validation
+   * to see if there is a valid default mode URL exist first. If URL is valid, pass in
+   * the actual URL; if not, pass in undefined.
+   *
+   * @param {boolean} darkMode
+   * @param {Readonly<OpenSearchDashboardsConfigType>} opensearchDashboardsConfig
+   * @returns {BrandingAssignment} valid URLs or undefined assigned for each branding configs
+   */
+  private assignBrandingConfig = async (
+    darkMode: boolean,
+    opensearchDashboardsConfig: Readonly<OpenSearchDashboardsConfigType>
+  ): Promise<BrandingAssignment> => {
+    const branding = opensearchDashboardsConfig.branding;
+
+    const skipValidation = false;
+    const logoDefaultConfig = branding.logo.defaultUrl;
+    const logoDarkmodeConfig = branding.logo.darkModeUrl;
+    const markDefaultConfig = branding.mark.defaultUrl;
+    const markDarkmodeConfig = branding.mark.darkModeUrl;
+    const loadingLogoDefaultConfig = branding.loadingLogo.defaultUrl;
+    const loadingLogoDarkmodeConfig = branding.loadingLogo.darkModeUrl;
+    const faviconConfig = branding.faviconUrl;
+    const applicationTitleConfig = branding.applicationTitle;
+
+    // use expanded menu by default unless explicitly set to false
+    const { useExpandedHeader = true } = branding;
+
+    /* if(skipValidation){
+      const branding = opensearchDashboardsConfig.branding;
+      const brandingWithoutValidation: BrandingAssignment= {
+        branding.logo.defaultUrl as logoDefaultConfig
+        logoDarkmodeConfig,
+        markDefaultConfig,
+        markDarkmodeConfig,
+        loadingLogoDefaultConfig,
+        loadingLogoDarkmodeConfig,
+        faviconConfig,
+        applicationTitleConfig,
+        useExpandedHeader,
+      }
+      return brandingWithoutValidation;
+    }*/
+
+    const brandingValidation: BrandingValidation = await this.checkBrandingValid(
+      skipValidation,
+      darkMode,
+      opensearchDashboardsConfig
+    );
+
+    // assign default mode URL based on the brandingValidation function result
+    const logoDefault = brandingValidation.isLogoDefaultValid ? logoDefaultConfig : undefined;
+
+    const markDefault = brandingValidation.isMarkDefaultValid ? markDefaultConfig : undefined;
+
+    const loadingLogoDefault = brandingValidation.isLoadingLogoDefaultValid
+      ? loadingLogoDefaultConfig
+      : undefined;
+
+    // assign dark mode URLs based on brandingValidation function result
+    let logoDarkmode = brandingValidation.isLogoDarkmodeValid ? logoDarkmodeConfig : undefined;
+
+    let markDarkmode = brandingValidation.isMarkDarkmodeValid ? markDarkmodeConfig : undefined;
+
+    let loadingLogoDarkmode = brandingValidation.isLoadingLogoDarkmodeValid
+      ? loadingLogoDarkmodeConfig
+      : undefined;
+
+    /**
+     * For dark mode URLs, we added another validation:
+     * user can only provide a dark mode URL after providing a valid default mode URL,
+     * If user provides a valid dark mode URL but fails to provide a valid default mode URL,
+     * return undefined for the dark mode URL
+     */
+    if (!skipValidation && logoDarkmode && !logoDefault) {
+      this.logger
+        .get('branding')
+        .error('Must provide a valid logo default mode URL before providing a logo dark mode URL');
+      logoDarkmode = undefined;
+    }
+
+    if (!skipValidation && markDarkmode && !markDefault) {
+      this.logger
+        .get('branding')
+        .error('Must provide a valid mark default mode URL before providing a mark dark mode URL');
+      markDarkmode = undefined;
+    }
+
+    if (!skipValidation && loadingLogoDarkmode && !loadingLogoDefault) {
+      this.logger
+        .get('branding')
+        .error(
+          'Must provide a valid loading logo default mode URL before providing a loading logo dark mode URL'
+        );
+      loadingLogoDarkmode = undefined;
+    }
+
+    // assign favicon based on brandingValidation function result
+    const favicon = brandingValidation.isFaviconValid ? faviconConfig : undefined;
+
+    // assign application title based on brandingValidation function result
+    const applicationTitle = brandingValidation.isTitleValid
+      ? applicationTitleConfig
+      : DEFAULT_TITLE;
+
+    const brandingAssignment: BrandingAssignment = {
+      logoDefault,
+      logoDarkmode,
+      markDefault,
+      markDarkmode,
+      loadingLogoDefault,
+      loadingLogoDarkmode,
+      favicon,
+      applicationTitle,
+      useExpandedHeader,
+    };
+
+    return brandingAssignment;
+  };
+
+  /**
+   * Assign boolean values for branding related configurations to indicate if
+   * user inputs valid or invalid URLs by calling isUrlValid() function. Also
+   * check if title is valid by calling isTitleValid() function.
+   *
+   * @param {boolean} darkMode
+   * @param {Readonly<OpenSearchDashboardsConfigType>} opensearchDashboardsConfig
+   * @returns {BrandingValidation} indicate valid/invalid URL for each branding config
+   */
+  private checkBrandingValid = async (
+    skipValidation: boolean,
+    darkMode: boolean,
+    opensearchDashboardsConfig: Readonly<OpenSearchDashboardsConfigType>
+  ): Promise<BrandingValidation> => {
+    const branding = opensearchDashboardsConfig.branding;
+    const isLogoDefaultValid = skipValidation
+      ? true
+      : await this.isUrlValid(branding.logo.defaultUrl, 'logo default');
+
+    const isLogoDarkmodeValid = skipValidation
+      ? true
+      : darkMode
+      ? await this.isUrlValid(branding.logo.darkModeUrl, 'logo darkMode')
+      : false;
+
+    const isMarkDefaultValid = skipValidation
+      ? true
+      : await this.isUrlValid(branding.mark.defaultUrl, 'mark default');
+
+    const isMarkDarkmodeValid = skipValidation
+      ? true
+      : darkMode
+      ? await this.isUrlValid(branding.mark.darkModeUrl, 'mark darkMode')
+      : false;
+
+    const isLoadingLogoDefaultValid = skipValidation
+      ? true
+      : await this.isUrlValid(branding.loadingLogo.defaultUrl, 'loadingLogo default');
+
+    const isLoadingLogoDarkmodeValid = skipValidation
+      ? true
+      : darkMode
+      ? await this.isUrlValid(branding.loadingLogo.darkModeUrl, 'loadingLogo darkMode')
+      : false;
+
+    const isFaviconValid = skipValidation
+      ? true
+      : await this.isUrlValid(branding.faviconUrl, 'favicon');
+
+    const isTitleValid = skipValidation
+      ? true
+      : this.isTitleValid(branding.applicationTitle, 'applicationTitle');
+
+    const brandingValidation: BrandingValidation = {
+      isLogoDefaultValid,
+      isLogoDarkmodeValid,
+      isMarkDefaultValid,
+      isMarkDarkmodeValid,
+      isLoadingLogoDefaultValid,
+      isLoadingLogoDarkmodeValid,
+      isFaviconValid,
+      isTitleValid,
+    };
+
+    return brandingValidation;
+  };
+
+  /**
+   * Validation function for URLs. Use Axios to call URL and check validity.
+   * Also needs to be ended with png, svg, gif, PNG, SVG and GIF.
+   *
+   * @param {string} url
+   * @param {string} configName
+   * @returns {boolean} indicate if the URL is valid/invalid
+   */
+  public isUrlValid = async (url: string, configName?: string): Promise<boolean> => {
+    if (url === '/') {
+      return false;
+    }
+    if (url.match(/\.(png|svg|gif|PNG|SVG|GIF)$/) === null) {
+      this.logger.get('branding').error(`${configName} config is invalid. Using default branding.`);
+      return false;
+    }
+    return await Axios.get(url, {
+      httpsAgent: this.httpsAgent,
+      adapter: AxiosHttpAdapter,
+      maxRedirects: 0,
+    })
+      .then(() => {
+        return true;
+      })
+      .catch(() => {
+        this.logger
+          .get('branding')
+          .error(`${configName} URL was not found or invalid. Using default branding.`);
+        return false;
+      });
+  };
+
+  /**
+   * Validation function for applicationTitle config.
+   * Title length needs to be between 1 to 36 letters.
+   *
+   * @param {string} title
+   * @param {string} configName
+   * @returns {boolean} indicate if user input title is valid/invalid
+   */
+  public isTitleValid = (title: string, configName?: string): boolean => {
+    if (!title) {
+      return false;
+    }
+    if (title.length > 36) {
+      this.logger
+        .get('branding')
+        .error(
+          `${configName} config is not found or invalid. Title length should be between 1 to 36 characters. Using default title.`
+        );
+      return false;
+    }
+    return true;
+  };
+}

--- a/src/core/server/branding_service/index.ts
+++ b/src/core/server/branding_service/index.ts
@@ -28,29 +28,5 @@
  * under the License.
  */
 
-/**
- * A type definition for custom branding configurations from yml file
- * @public
- */
-
-export interface Branding {
-  /** Default mode or Dark mode*/
-  darkMode?: boolean;
-  /** Relative path to the asset folder */
-  assetFolderUrl?: string;
-  /** Small logo icon that will be used in most logo occurrences */
-  mark?: string;
-  /** Fuller logo that will be rendered on nav bar header */
-  logo?: string;
-  /** Loading logo that will be rendered on the loading page */
-  loadingLogo?: {
-    url?: string;
-    loadBar?: boolean;
-  };
-  /** Custom favicon that will be rendered on the browser tab */
-  faviconUrl?: string;
-  /** Application title that will replace the default opensearch dashboard string */
-  applicationTitle?: string;
-  /** Whether to use expanded menu (true) or condensed menu (false) */
-  useExpandedHeader?: boolean;
-}
+export { BrandingService } from './branding_service';
+export * from './types';

--- a/src/core/server/branding_service/types.ts
+++ b/src/core/server/branding_service/types.ts
@@ -1,0 +1,85 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { i18n } from '@osd/i18n';
+
+import { Branding } from 'src/core/types';
+import { EnvironmentMode, PackageInfo } from '../config';
+import { ICspConfig } from '../csp';
+import { InternalHttpServiceSetup, OpenSearchDashboardsRequest, LegacyRequest } from '../http';
+import { UiPlugins, DiscoveredPlugin } from '../plugins';
+import { IUiSettingsClient, UserProvidedValues } from '../ui_settings';
+import type { InternalStatusServiceSetup } from '../status';
+
+/**
+ * For each string branding config:
+ * check if user provides a valid string.
+ * Assign True -- if user provides a valid string
+ * Assign False -- if user provides an invalid string or user does not provide any string
+ */
+export interface BrandingValidation {
+  isLogoDefaultValid: boolean;
+  isLogoDarkmodeValid: boolean;
+  isMarkDefaultValid: boolean;
+  isMarkDarkmodeValid: boolean;
+  isLoadingLogoDefaultValid: boolean;
+  isLoadingLogoDarkmodeValid: boolean;
+  isFaviconValid: boolean;
+  isTitleValid: boolean;
+}
+
+/**
+ * For each branding config:
+ * if user provides a valid value, the value will be assigned;
+ * otherwise, undefined will be assigned.
+ */
+export interface BrandingAssignment {
+  logoDefault?: string;
+  logoDarkmode?: string;
+  markDefault?: string;
+  markDarkmode?: string;
+  loadingLogoDefault?: string;
+  loadingLogoDarkmode?: string;
+  favicon?: string;
+  applicationTitle?: string;
+  useExpandedHeader?: boolean;
+}
+
+export interface BrandingAssignmentWithoutValidation {
+  logoDefaultConfig: string;
+  logoDarkmodeConfig: string;
+  markDefaultConfig: string;
+  markDarkmodeConfig: string;
+  loadingLogoDefaultConfig: string;
+  loadingLogoDarkmodeConfig: string;
+  faviconConfig: string;
+  applicationTitleConfig: string;
+  useExpandedHeader: boolean;
+}

--- a/src/core/server/rendering/rendering_service.tsx
+++ b/src/core/server/rendering/rendering_service.tsx
@@ -32,9 +32,7 @@ import React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { first, take } from 'rxjs/operators';
 import { i18n } from '@osd/i18n';
-import { Agent as HttpsAgent } from 'https';
 
-import Axios from 'axios';
 // @ts-expect-error untyped internal module used to prevent axios from using xhr adapter in tests
 import AxiosHttpAdapter from 'axios/lib/adapters/http';
 import { UiPlugins } from '../plugins';
@@ -45,39 +43,21 @@ import {
   RenderingSetupDeps,
   InternalRenderingServiceSetup,
   RenderingMetadata,
-  BrandingValidation,
-  BrandingAssignment,
 } from './types';
-import { OpenSearchDashboardsConfigType } from '../opensearch_dashboards_config';
-import { HttpConfigType } from '../http/http_config';
-import { SslConfig } from '../http/ssl_config';
-import { LoggerFactory } from '../logging';
-
-const DEFAULT_TITLE = 'OpenSearch Dashboards';
+import { BrandingService } from '../branding_service';
 
 /** @internal */
 export class RenderingService {
+  private readonly branding: BrandingService;
   constructor(private readonly coreContext: CoreContext) {
-    this.logger = this.coreContext.logger;
+    this.branding = new BrandingService(coreContext);
   }
-  private logger: LoggerFactory;
-  private httpsAgent?: HttpsAgent;
 
   public async setup({
     http,
     status,
     uiPlugins,
   }: RenderingSetupDeps): Promise<InternalRenderingServiceSetup> {
-    const [opensearchDashboardsConfig, serverConfig] = await Promise.all([
-      this.coreContext.configService
-        .atPath<OpenSearchDashboardsConfigType>('opensearchDashboards')
-        .pipe(first())
-        .toPromise(),
-      this.coreContext.configService.atPath<HttpConfigType>('server').pipe(first()).toPromise(),
-    ]);
-
-    this.setupHttpAgent(serverConfig as HttpConfigType);
-
     return {
       render: async (
         request,
@@ -98,11 +78,7 @@ export class RenderingService {
         const darkMode = settings.user?.['theme:darkMode']?.userValue
           ? Boolean(settings.user['theme:darkMode'].userValue)
           : false;
-
-        const brandingAssignment = await this.assignBrandingConfig(
-          darkMode,
-          opensearchDashboardsConfig as OpenSearchDashboardsConfigType
-        );
+        const branding = await this.branding.setup(darkMode, uiPublicUrl);
 
         const metadata: RenderingMetadata = {
           strictCsp: http.csp.strict,
@@ -134,270 +110,21 @@ export class RenderingService {
             legacyMetadata: {
               uiSettings: settings,
             },
-            branding: {
-              darkMode,
-              assetFolderUrl: `${uiPublicUrl}/default_branding`,
-              logo: {
-                defaultUrl: brandingAssignment.logoDefault,
-                darkModeUrl: brandingAssignment.logoDarkmode,
-              },
-              mark: {
-                defaultUrl: brandingAssignment.markDefault,
-                darkModeUrl: brandingAssignment.markDarkmode,
-              },
-              loadingLogo: {
-                defaultUrl: brandingAssignment.loadingLogoDefault,
-                darkModeUrl: brandingAssignment.loadingLogoDarkmode,
-              },
-              faviconUrl: brandingAssignment.favicon,
-              applicationTitle: brandingAssignment.applicationTitle,
-              useExpandedHeader: brandingAssignment.useExpandedHeader,
-            },
           },
         };
 
-        return `<!DOCTYPE html>${renderToStaticMarkup(<Template metadata={metadata} />)}`;
+        return `<!DOCTYPE html>${renderToStaticMarkup(
+          <Template metadata={metadata} branding={branding} />
+        )}`;
       },
     };
   }
 
   public async stop() {}
 
-  /**
-   * Setups HTTP Agent if SSL is enabled to pass SSL config
-   * values to Axios to make requests in while validating
-   * resources.
-   *
-   * @param {Readonly<HttpConfigType>} httpConfig
-   */
-  private setupHttpAgent(httpConfig: Readonly<HttpConfigType>) {
-    if (!httpConfig.ssl?.enabled) return;
-    try {
-      const sslConfig = new SslConfig(httpConfig.ssl);
-      this.httpsAgent = new HttpsAgent({
-        ca: sslConfig.certificateAuthorities,
-        cert: sslConfig.certificate,
-        key: sslConfig.key,
-        passphrase: sslConfig.keyPassphrase,
-        rejectUnauthorized: false,
-      });
-    } catch (e) {
-      this.logger.get('branding').error('HTTP agent failed to setup for SSL.');
-    }
-  }
-
-  /**
-   * Assign values for branding related configurations based on branding validation
-   * by calling checkBrandingValid(). For dark mode URLs, add additonal validation
-   * to see if there is a valid default mode URL exist first. If URL is valid, pass in
-   * the actual URL; if not, pass in undefined.
-   *
-   * @param {boolean} darkMode
-   * @param {Readonly<OpenSearchDashboardsConfigType>} opensearchDashboardsConfig
-   * @returns {BrandingAssignment} valid URLs or undefined assigned for each branding configs
-   */
-  private assignBrandingConfig = async (
-    darkMode: boolean,
-    opensearchDashboardsConfig: Readonly<OpenSearchDashboardsConfigType>
-  ): Promise<BrandingAssignment> => {
-    const brandingValidation: BrandingValidation = await this.checkBrandingValid(
-      darkMode,
-      opensearchDashboardsConfig
-    );
-    const branding = opensearchDashboardsConfig.branding;
-
-    // assign default mode URL based on the brandingValidation function result
-    const logoDefault = brandingValidation.isLogoDefaultValid
-      ? branding.logo.defaultUrl
-      : undefined;
-
-    const markDefault = brandingValidation.isMarkDefaultValid
-      ? branding.mark.defaultUrl
-      : undefined;
-
-    const loadingLogoDefault = brandingValidation.isLoadingLogoDefaultValid
-      ? branding.loadingLogo.defaultUrl
-      : undefined;
-
-    // assign dark mode URLs based on brandingValidation function result
-    let logoDarkmode = brandingValidation.isLogoDarkmodeValid
-      ? branding.logo.darkModeUrl
-      : undefined;
-
-    let markDarkmode = brandingValidation.isMarkDarkmodeValid
-      ? branding.mark.darkModeUrl
-      : undefined;
-
-    let loadingLogoDarkmode = brandingValidation.isLoadingLogoDarkmodeValid
-      ? branding.loadingLogo.darkModeUrl
-      : undefined;
-
-    /**
-     * For dark mode URLs, we added another validation:
-     * user can only provide a dark mode URL after providing a valid default mode URL,
-     * If user provides a valid dark mode URL but fails to provide a valid default mode URL,
-     * return undefined for the dark mode URL
-     */
-    if (logoDarkmode && !logoDefault) {
-      this.logger
-        .get('branding')
-        .error('Must provide a valid logo default mode URL before providing a logo dark mode URL');
-      logoDarkmode = undefined;
-    }
-
-    if (markDarkmode && !markDefault) {
-      this.logger
-        .get('branding')
-        .error('Must provide a valid mark default mode URL before providing a mark dark mode URL');
-      markDarkmode = undefined;
-    }
-
-    if (loadingLogoDarkmode && !loadingLogoDefault) {
-      this.logger
-        .get('branding')
-        .error(
-          'Must provide a valid loading logo default mode URL before providing a loading logo dark mode URL'
-        );
-      loadingLogoDarkmode = undefined;
-    }
-
-    // assign favicon based on brandingValidation function result
-    const favicon = brandingValidation.isFaviconValid ? branding.faviconUrl : undefined;
-
-    // assign application title based on brandingValidation function result
-    const applicationTitle = brandingValidation.isTitleValid
-      ? branding.applicationTitle
-      : DEFAULT_TITLE;
-
-    // use expanded menu by default unless explicitly set to false
-    const { useExpandedHeader = true } = branding;
-
-    const brandingAssignment: BrandingAssignment = {
-      logoDefault,
-      logoDarkmode,
-      markDefault,
-      markDarkmode,
-      loadingLogoDefault,
-      loadingLogoDarkmode,
-      favicon,
-      applicationTitle,
-      useExpandedHeader,
-    };
-
-    return brandingAssignment;
-  };
-
-  /**
-   * Assign boolean values for branding related configurations to indicate if
-   * user inputs valid or invalid URLs by calling isUrlValid() function. Also
-   * check if title is valid by calling isTitleValid() function.
-   *
-   * @param {boolean} darkMode
-   * @param {Readonly<OpenSearchDashboardsConfigType>} opensearchDashboardsConfig
-   * @returns {BrandingValidation} indicate valid/invalid URL for each branding config
-   */
-  private checkBrandingValid = async (
-    darkMode: boolean,
-    opensearchDashboardsConfig: Readonly<OpenSearchDashboardsConfigType>
-  ): Promise<BrandingValidation> => {
-    const branding = opensearchDashboardsConfig.branding;
-    const isLogoDefaultValid = await this.isUrlValid(branding.logo.defaultUrl, 'logo default');
-
-    const isLogoDarkmodeValid = darkMode
-      ? await this.isUrlValid(branding.logo.darkModeUrl, 'logo darkMode')
-      : false;
-
-    const isMarkDefaultValid = await this.isUrlValid(branding.mark.defaultUrl, 'mark default');
-
-    const isMarkDarkmodeValid = darkMode
-      ? await this.isUrlValid(branding.mark.darkModeUrl, 'mark darkMode')
-      : false;
-
-    const isLoadingLogoDefaultValid = await this.isUrlValid(
-      branding.loadingLogo.defaultUrl,
-      'loadingLogo default'
-    );
-
-    const isLoadingLogoDarkmodeValid = darkMode
-      ? await this.isUrlValid(branding.loadingLogo.darkModeUrl, 'loadingLogo darkMode')
-      : false;
-
-    const isFaviconValid = await this.isUrlValid(branding.faviconUrl, 'favicon');
-
-    const isTitleValid = this.isTitleValid(branding.applicationTitle, 'applicationTitle');
-
-    const brandingValidation: BrandingValidation = {
-      isLogoDefaultValid,
-      isLogoDarkmodeValid,
-      isMarkDefaultValid,
-      isMarkDarkmodeValid,
-      isLoadingLogoDefaultValid,
-      isLoadingLogoDarkmodeValid,
-      isFaviconValid,
-      isTitleValid,
-    };
-
-    return brandingValidation;
-  };
-
   private async getUiConfig(uiPlugins: UiPlugins, pluginId: string) {
     const browserConfig = uiPlugins.browserConfigs.get(pluginId);
 
     return ((await browserConfig?.pipe(take(1)).toPromise()) ?? {}) as Record<string, any>;
   }
-
-  /**
-   * Validation function for URLs. Use Axios to call URL and check validity.
-   * Also needs to be ended with png, svg, gif, PNG, SVG and GIF.
-   *
-   * @param {string} url
-   * @param {string} configName
-   * @returns {boolean} indicate if the URL is valid/invalid
-   */
-  public isUrlValid = async (url: string, configName?: string): Promise<boolean> => {
-    if (url === '/') {
-      return false;
-    }
-    if (url.match(/\.(png|svg|gif|PNG|SVG|GIF)$/) === null) {
-      this.logger.get('branding').error(`${configName} config is invalid. Using default branding.`);
-      return false;
-    }
-    return await Axios.get(url, {
-      httpsAgent: this.httpsAgent,
-      adapter: AxiosHttpAdapter,
-      maxRedirects: 0,
-    })
-      .then(() => {
-        return true;
-      })
-      .catch(() => {
-        this.logger
-          .get('branding')
-          .error(`${configName} URL was not found or invalid. Using default branding.`);
-        return false;
-      });
-  };
-
-  /**
-   * Validation function for applicationTitle config.
-   * Title length needs to be between 1 to 36 letters.
-   *
-   * @param {string} title
-   * @param {string} configName
-   * @returns {boolean} indicate if user input title is valid/invalid
-   */
-  public isTitleValid = (title: string, configName?: string): boolean => {
-    if (!title) {
-      return false;
-    }
-    if (title.length > 36) {
-      this.logger
-        .get('branding')
-        .error(
-          `${configName} config is not found or invalid. Title length should be between 1 to 36 characters. Using default title.`
-        );
-      return false;
-    }
-    return true;
-  };
 }

--- a/src/core/server/rendering/types.ts
+++ b/src/core/server/rendering/types.ts
@@ -30,7 +30,6 @@
 
 import { i18n } from '@osd/i18n';
 
-import { Branding } from 'src/core/types';
 import { EnvironmentMode, PackageInfo } from '../config';
 import { ICspConfig } from '../csp';
 import { InternalHttpServiceSetup, OpenSearchDashboardsRequest, LegacyRequest } from '../http';
@@ -73,7 +72,6 @@ export interface RenderingMetadata {
         user: Record<string, UserProvidedValues<any>>;
       };
     };
-    branding: Branding;
   };
 }
 
@@ -116,38 +114,4 @@ export interface InternalRenderingServiceSetup {
     uiSettings: IUiSettingsClient,
     options?: IRenderOptions
   ): Promise<string>;
-}
-
-/**
- * For each string branding config:
- * check if user provides a valid string.
- * Assign True -- if user provides a valid string
- * Assign False -- if user provides an invalid string or user does not provide any string
- */
-export interface BrandingValidation {
-  isLogoDefaultValid: boolean;
-  isLogoDarkmodeValid: boolean;
-  isMarkDefaultValid: boolean;
-  isMarkDarkmodeValid: boolean;
-  isLoadingLogoDefaultValid: boolean;
-  isLoadingLogoDarkmodeValid: boolean;
-  isFaviconValid: boolean;
-  isTitleValid: boolean;
-}
-
-/**
- * For each branding config:
- * if user provides a valid value, the value will be assigned;
- * otherwise, undefined will be assigned.
- */
-export interface BrandingAssignment {
-  logoDefault?: string;
-  logoDarkmode?: string;
-  markDefault?: string;
-  markDarkmode?: string;
-  loadingLogoDefault?: string;
-  loadingLogoDarkmode?: string;
-  favicon?: string;
-  applicationTitle?: string;
-  useExpandedHeader?: boolean;
 }

--- a/src/core/server/rendering/views/template.tsx
+++ b/src/core/server/rendering/views/template.tsx
@@ -33,9 +33,11 @@ import React, { FunctionComponent, createElement } from 'react';
 import { RenderingMetadata } from '../types';
 import { Fonts } from './fonts';
 import { Styles } from './styles';
+import { Branding } from '../../types';
 
 interface Props {
   metadata: RenderingMetadata;
+  branding: Branding;
 }
 
 export const Template: FunctionComponent<Props> = ({
@@ -48,6 +50,7 @@ export const Template: FunctionComponent<Props> = ({
     bootstrapScriptUrl,
     strictCsp,
   },
+  branding,
 }) => {
   const openSearchLogo = (
     <svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -94,45 +97,10 @@ export const Template: FunctionComponent<Props> = ({
     </svg>
   );
 
-  const loadingLogoDefault = injectedMetadata.branding.loadingLogo?.defaultUrl;
-  const loadingLogoDarkMode = injectedMetadata.branding.loadingLogo?.darkModeUrl;
-  const markDefault = injectedMetadata.branding.mark?.defaultUrl;
-  const markDarkMode = injectedMetadata.branding.mark?.darkModeUrl;
-  const favicon = injectedMetadata.branding.faviconUrl;
-  const applicationTitle = injectedMetadata.branding.applicationTitle;
-
-  /**
-   * Use branding configurations to check which URL to use for rendering
-   * loading logo in default mode. In default mode, loading logo will
-   * proritize default loading logo URL, and then default mark URL.
-   * If both are invalid, default opensearch logo and spinner will be rendered.
-   *
-   * @returns a valid custom URL or undefined if no valid URL is provided
-   */
-  const customLoadingLogoDefaultMode = () => {
-    return loadingLogoDefault ?? markDefault ?? undefined;
-  };
-
-  /**
-   * Use branding configurations to check which URL to use for rendering
-   * loading logo in default mode. In dark mode, loading logo will proritize
-   * loading logo URLs, then mark logo URLs.
-   * Within each type, the dark mode URL will be proritized if provided.
-   *
-   * @returns a valid custom URL or undefined if no valid URL is provided
-   */
-  const customLoadingLogoDarkMode = () => {
-    return loadingLogoDarkMode ?? loadingLogoDefault ?? markDarkMode ?? markDefault ?? undefined;
-  };
-
-  /**
-   * Render custom loading logo for both default mode and dark mode
-   *
-   * @returns a valid custom loading logo URL, or undefined
-   */
-  const customLoadingLogo = () => {
-    return darkMode ? customLoadingLogoDarkMode() : customLoadingLogoDefaultMode();
-  };
+  const loadingLogo = branding.loadingLogo?.url;
+  const loadBar = branding.loadingLogo?.loadBar;
+  const favicon = branding.faviconUrl;
+  const applicationTitle = branding.applicationTitle;
 
   /**
    * Check if a horizontal loading is needed to be rendered.
@@ -144,7 +112,7 @@ export const Template: FunctionComponent<Props> = ({
    * @returns a loading bar component or no loading bar component
    */
   const renderBrandingEnabledOrDisabledLoadingBar = () => {
-    if (customLoadingLogo() && !loadingLogoDefault) {
+    if (loadBar) {
       return <div className="osdProgress" />;
     }
   };
@@ -157,10 +125,10 @@ export const Template: FunctionComponent<Props> = ({
    * @returns a image component with custom logo URL, or the default opensearch logo spinner
    */
   const renderBrandingEnabledOrDisabledLoadingLogo = () => {
-    if (customLoadingLogo()) {
+    if (loadingLogo) {
       return (
         <div className="loadingLogoContainer">
-          <img className="loadingLogo" src={customLoadingLogo()} alt={applicationTitle + ' logo'} />
+          <img className="loadingLogo" src={loadingLogo} alt={applicationTitle + ' logo'} />
         </div>
       );
     }
@@ -235,6 +203,7 @@ export const Template: FunctionComponent<Props> = ({
           data: JSON.stringify({ strictCsp }),
         })}
         {createElement('osd-injected-metadata', { data: JSON.stringify(injectedMetadata) })}
+        {createElement('osd-branding', { data: JSON.stringify(branding) })}
         <div
           className="osdWelcomeView"
           id="osd_loading_message"
@@ -246,11 +215,11 @@ export const Template: FunctionComponent<Props> = ({
             <div
               className="osdWelcomeText"
               data-error-message={i18n('core.ui.welcomeErrorMessage', {
-                defaultMessage: `${injectedMetadata.branding.applicationTitle} did not load properly. Check the server output for more information.`,
+                defaultMessage: `${branding.applicationTitle} did not load properly. Check the server output for more information.`,
               })}
             >
               {i18n('core.ui.welcomeMessage', {
-                defaultMessage: `Loading ${injectedMetadata.branding.applicationTitle}`,
+                defaultMessage: `Loading ${branding.applicationTitle}`,
               })}
             </div>
             {renderBrandingEnabledOrDisabledLoadingBar()}

--- a/src/plugins/home/public/application/components/home.js
+++ b/src/plugins/home/public/application/components/home.js
@@ -153,7 +153,7 @@ export class Home extends Component {
           showDevToolsLink
           showManagementLink
           title={<FormattedMessage id="home.header.title" defaultMessage="Home" />}
-          branding={getServices().injectedMetadata.getBranding()}
+          branding={getServices().injectedBranding.getBranding()}
         />
 
         <div className="homContent">
@@ -162,7 +162,7 @@ export class Home extends Component {
               addBasePath={addBasePath}
               solutions={solutions}
               directories={directories}
-              branding={getServices().injectedMetadata.getBranding()}
+              branding={getServices().injectedBranding.getBranding()}
             />
           ) : null}
 
@@ -201,7 +201,7 @@ export class Home extends Component {
         onSkip={this.skipWelcome}
         urlBasePath={this.props.urlBasePath}
         telemetry={this.props.telemetry}
-        branding={getServices().injectedMetadata.getBranding()}
+        branding={getServices().injectedBranding.getBranding()}
       />
     );
   }

--- a/src/plugins/home/public/application/components/solutions_section/solution_title.tsx
+++ b/src/plugins/home/public/application/components/solutions_section/solution_title.tsx
@@ -56,43 +56,6 @@ interface Props {
 }
 
 /**
- * Use branding configurations to check which URL to use for rendering
- * home card logo in default mode. In default mode, home card logo will
- * proritize default mode mark URL. If it is invalid, default opensearch logo
- * will be rendered.
- *
- * @param {HomePluginBranding} - pass in custom branding configurations
- * @returns a valid custom URL or undefined if no valid URL is provided
- */
-const customHomeLogoDefaultMode = (branding: HomePluginBranding) => {
-  return branding.mark?.defaultUrl ?? undefined;
-};
-
-/**
- * Use branding configurations to check which URL to use for rendering
- * home logo in dark mode. In dark mode, home logo will render
- * dark mode mark URL if valid. Otherwise, it will render the default
- * mode mark URL if valid. If both dark mode mark URL and default mode mark
- * URL are invalid, the default opensearch logo will be rendered.
- *
- * @param {HomePluginBranding} - pass in custom branding configurations
- * @returns {string|undefined} a valid custom URL or undefined if no valid URL is provided
- */
-const customHomeLogoDarkMode = (branding: HomePluginBranding) => {
-  return branding.mark?.darkModeUrl ?? branding.mark?.defaultUrl ?? undefined;
-};
-
-/**
- * Render custom home logo for both default mode and dark mode
- *
- * @param {HomePluginBranding} - pass in custom branding configurations
- * @returns {string|undefined} a valid custom loading logo URL, or undefined
- */
-const customHomeLogo = (branding: HomePluginBranding) => {
-  return branding.darkMode ? customHomeLogoDarkMode(branding) : customHomeLogoDefaultMode(branding);
-};
-
-/**
  * Check if we render a custom home logo or the default opensearch spinner.
  * If customWelcomeLogo() returns undefined(no valid custom URL is found), we
  * render the default opensearch logo
@@ -101,16 +64,15 @@ const customHomeLogo = (branding: HomePluginBranding) => {
  * @returns a image component with custom logo URL, or the default opensearch logo
  */
 const renderBrandingEnabledOrDisabledLogo = (branding: HomePluginBranding) => {
-  const customLogo = customHomeLogo(branding);
-  if (customLogo) {
+  if (branding.mark) {
     return (
       <div className="homSolutionPanel__customIcon">
         <img
           className="homSolutionPanel__customIconContainer"
           data-test-subj="dashboardCustomLogo"
-          data-test-image-url={customLogo}
+          data-test-image-url={branding.mark}
           alt={branding.applicationTitle + ' logo'}
-          src={customLogo}
+          src={branding.mark}
         />
       </div>
     );

--- a/src/plugins/home/public/application/components/welcome.tsx
+++ b/src/plugins/home/public/application/components/welcome.tsx
@@ -58,10 +58,7 @@ interface Props {
   telemetry?: TelemetryPluginStart;
   branding: {
     darkMode: boolean;
-    mark: {
-      defaultUrl?: string;
-      darkModeUrl?: string;
-    };
+    mark?: string;
     applicationTitle?: string;
   };
 }
@@ -146,47 +143,8 @@ export class Welcome extends React.Component<Props> {
     }
   };
 
-  private darkMode = this.props.branding.darkMode;
-  private markDefault = this.props.branding.mark.defaultUrl;
-  private markDarkMode = this.props.branding.mark.darkModeUrl;
+  private mark = this.props.branding.mark;
   private applicationTitle = this.props.branding.applicationTitle;
-
-  /**
-   * Use branding configurations to check which URL to use for rendering
-   * welcome logo in default mode. In default mode, welcome logo will
-   * proritize default mode mark URL. If it is invalid, default opensearch logo
-   * will be rendered.
-   *
-   * @returns a valid custom URL or undefined if no valid URL is provided
-   */
-  private customWelcomeLogoDefaultMode = () => {
-    return this.markDefault ?? undefined;
-  };
-
-  /**
-   * Use branding configurations to check which URL to use for rendering
-   * welcome logo in dark mode. In dark mode, welcome logo will render
-   * dark mode mark URL if valid. Otherwise, it will render the default
-   * mode mark URL if valid. If both dark mode mark URL and default mode mark
-   * URL are invalid, the default opensearch logo will be rendered.
-   *
-   * @returns a valid custom URL or undefined if no valid URL is provided
-   */
-  private customWelcomeLogoDarkMode = () => {
-    return this.markDarkMode ?? this.markDefault ?? undefined;
-  };
-
-  /**
-   * Render custom welcome logo for both default mode and dark mode
-   *
-   * @returns a valid custom loading logo URL, or undefined
-   */
-  private customWelcomeLogo = () => {
-    if (this.darkMode) {
-      return this.customWelcomeLogoDarkMode();
-    }
-    return this.customWelcomeLogoDefaultMode();
-  };
 
   /**
    * Check if we render a custom welcome logo or the default opensearch spinner.
@@ -196,15 +154,15 @@ export class Welcome extends React.Component<Props> {
    * @returns a image component with custom logo URL, or the default opensearch logo
    */
   private renderBrandingEnabledOrDisabledLogo = () => {
-    if (this.customWelcomeLogo()) {
+    if (this.mark) {
       return (
         <div className="homWelcome__customLogoContainer">
           <img
             className="homWelcome__customLogo"
             data-test-subj="welcomeCustomLogo"
-            data-test-image-url={this.customWelcomeLogo()}
+            data-test-image-url={this.mark}
             alt={this.applicationTitle + ' logo'}
-            src={this.customWelcomeLogo()}
+            src={this.mark}
           />
         </div>
       );

--- a/src/plugins/home/public/application/opensearch_dashboards_services.ts
+++ b/src/plugins/home/public/application/opensearch_dashboards_services.ts
@@ -69,6 +69,8 @@ export interface HomeOpenSearchDashboardsServices {
   tutorialService: TutorialService;
   injectedMetadata: {
     getInjectedVar: (name: string, defaultValue?: any) => unknown;
+  };
+  injectedBranding: {
     getBranding: () => HomePluginBranding;
   };
 }

--- a/src/plugins/home/public/plugin.ts
+++ b/src/plugins/home/public/plugin.ts
@@ -119,6 +119,7 @@ export class HomePublicPlugin
           tutorialService: this.tutorialService,
           featureCatalogue: this.featuresCatalogueRegistry,
           injectedMetadata: coreStart.injectedMetadata,
+          injectedBranding: coreStart.injectedBranding,
         });
         coreStart.chrome.docTitle.change(
           i18n.translate('home.pageTitle', { defaultMessage: 'Home' })

--- a/src/plugins/opensearch_dashboards_overview/public/application.tsx
+++ b/src/plugins/opensearch_dashboards_overview/public/application.tsx
@@ -51,7 +51,7 @@ export const renderApp = (
     .filter(({ id }) => id !== 'opensearchDashboards')
     .filter(({ id }) => navLinks.find(({ category, hidden }) => !hidden && category?.id === id));
   const features = home.featureCatalogue.get();
-  const branding = core.injectedMetadata.getBranding();
+  const branding = core.injectedBranding.getBranding();
 
   ReactDOM.render(
     <I18nProvider>

--- a/src/plugins/opensearch_dashboards_react/public/overview_page/overview_page_header/overview_page_header.tsx
+++ b/src/plugins/opensearch_dashboards_react/public/overview_page/overview_page_header/overview_page_header.tsx
@@ -79,33 +79,6 @@ export const OverviewPageHeader: FC<Props> = ({
   const DARKMODE_OPENSEARCH_MARK = `${branding.assetFolderUrl}/opensearch_mark_dark_mode.svg`;
 
   const darkMode = branding.darkMode;
-  const markDefault = branding.mark?.defaultUrl;
-  const markDarkMode = branding.mark?.darkModeUrl;
-
-  /**
-   * Use branding configurations to check which URL to use for rendering
-   * overview logo in default mode. In default mode, overview logo will
-   * proritize default mode mark URL. If it is invalid, default opensearch logo
-   * will be rendered.
-   *
-   * @returns a valid custom URL or undefined if no valid URL is provided
-   */
-  const customOverviewLogoDefaultMode = () => {
-    return markDefault ?? DEFAULT_OPENSEARCH_MARK;
-  };
-
-  /**
-   * Use branding configurations to check which URL to use for rendering
-   * overview logo in dark mode. In dark mode, overview logo will render
-   * dark mode mark URL if valid. Otherwise, it will render the default
-   * mode mark URL if valid. If both dark mode mark URL and default mode mark
-   * URL are invalid, the default opensearch logo will be rendered.
-   *
-   * @returns a valid custom URL or undefined if no valid URL is provided
-   */
-  const customOverviewLogoDarkMode = () => {
-    return markDarkMode ?? markDefault ?? DARKMODE_OPENSEARCH_MARK;
-  };
 
   /**
    * Render custom overview logo for both default mode and dark mode
@@ -113,7 +86,7 @@ export const OverviewPageHeader: FC<Props> = ({
    * @returns a valid custom loading logo URL, or undefined
    */
   const customOverviewLogo = () => {
-    return darkMode ? customOverviewLogoDarkMode() : customOverviewLogoDefaultMode();
+    return branding.mark ?? (darkMode ? DARKMODE_OPENSEARCH_MARK : DEFAULT_OPENSEARCH_MARK);
   };
 
   /**


### PR DESCRIPTION
### Description
This PR is a rough draft that creates a new branding service to handle all custom branding related logic to reduce duplication. I have verified it works for all logo occurrences including default mode and dark mode. It does not include any tests yet.

Here is one potential implementation: 
1. On the server side: A new branding service is created. Previously the logics including retrieving branding configs from yml file, branding validation, http agent logic to solve ssl failure are all stored in the rendering service. Currently the newly created branding service will handle all those logic and the rendering service will just call the branding service to get all the branding information.
2. Previously the branding info is passed in the metadata, currently it will be passed separately from the metadata. It will be rendered as 'osd-branding' in the html, instead of being part of the 'osd-injected-metadata'.
3. On the public side: A new injected branding service is created. Previously the application uses injected metadata service to retrieve the branding information from the core system. Since we have separate branding data out of metadata, now we can just use injected branding service.
 
### Issues Resolved
One possible implementation: Service that components can hook into that assists with the logic
Part of the design spike: https://github.com/opensearch-project/OpenSearch-Dashboards/issues/2045
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
    - [ ] `yarn test:jest`
    - [ ] `yarn test:jest_integration`
    - [ ] `yarn test:ftr`
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff 