### PR TITLE
[Draft] Extend rendering service 

### DIFF
--- a/config/opensearch_dashboards.yml
+++ b/config/opensearch_dashboards.yml
@@ -163,19 +163,19 @@
 # ]
 #vis_type_timeline.graphiteBlockedIPs: []
 
-# opensearchDashboards.branding:
-#   logo:
-#     defaultUrl: ""
-#     darkModeUrl: ""
-#   mark:
-#     defaultUrl: ""
-#     darkModeUrl: ""
-#   loadingLogo:
-#     defaultUrl: ""
-#     darkModeUrl: ""
+ opensearchDashboards.branding:
+   logo:
+     defaultUrl: "https://clipground.com/images/aws-logo-png-9.png"
+     darkModeUrl: "https://vectorified.com/image/aws-logo-vector-5.png"
+   #mark:
+     #defaultUrl: "https://pngimage.net/wp-content/uploads/2020/02/aws-logo-png-4.png"
+     #darkModeUrl: "https://abacusinsights.com/wp-content/uploads/2019/07/logo-AWS.png"
+   #loadingLogo:
+     #defaultUrl: "https://mir-s3-cdn-cf.behance.net/project_modules/max_1200/d31fcf75226323.5c4702fb7ef89.gif"
+     #darkModeUrl: "https://gifimage.net/wp-content/uploads/2018/05/sparkler-gif-9.gif"
 #   faviconUrl: ""
 #   applicationTitle: ""
-#   useExpandedHeader: false
+   useExpandedHeader: true
 
 # Set the value of this setting to true to capture region blocked warnings and errors
 # for your map rendering services.

--- a/src/core/public/chrome/ui/header/collapsible_nav.tsx
+++ b/src/core/public/chrome/ui/header/collapsible_nav.tsx
@@ -142,8 +142,8 @@ export function CollapsibleNav({
   const DARKMODE_OPENSEARCH_MARK = `${branding.assetFolderUrl}/opensearch_mark_dark_mode.svg`;
 
   const darkMode = branding.darkMode;
-  const markDefault = branding.mark?.defaultUrl;
-  const markDarkMode = branding.mark?.darkModeUrl;
+  const mark = branding.mark?.defaultUrl;
+  // const markDarkMode = branding.mark?.darkModeUrl;
 
   /**
    * Use branding configurations to check which URL to use for rendering
@@ -151,9 +151,9 @@ export function CollapsibleNav({
    *
    * @returns a valid custom URL or original default mode opensearch mark if no valid URL is provided
    */
-  const customSideMenuLogoDefaultMode = () => {
+  /* const customSideMenuLogoDefaultMode = () => {
     return markDefault ?? DEFAULT_OPENSEARCH_MARK;
-  };
+  };*/
 
   /**
    * Use branding configurations to check which URL to use for rendering
@@ -161,9 +161,9 @@ export function CollapsibleNav({
    *
    * @returns a valid custom URL or original dark mode opensearch mark if no valid URL is provided
    */
-  const customSideMenuLogoDarkMode = () => {
+  /* const customSideMenuLogoDarkMode = () => {
     return markDarkMode ?? markDefault ?? DARKMODE_OPENSEARCH_MARK;
-  };
+  };*/
 
   /**
    * Render custom side menu logo for both default mode and dark mode
@@ -171,7 +171,8 @@ export function CollapsibleNav({
    * @returns a valid logo URL
    */
   const customSideMenuLogo = () => {
-    return darkMode ? customSideMenuLogoDarkMode() : customSideMenuLogoDefaultMode();
+    // console.log(mark)
+    return mark ?? (darkMode ? DARKMODE_OPENSEARCH_MARK : DEFAULT_OPENSEARCH_MARK);
   };
 
   return (

--- a/src/core/public/chrome/ui/header/header_logo.tsx
+++ b/src/core/public/chrome/ui/header/header_logo.tsx
@@ -116,9 +116,9 @@ export function HeaderLogo({ href, navigateToApp, branding, ...observables }: Pr
     logo = {},
     applicationTitle = 'opensearch dashboards',
   } = branding;
-  const { defaultUrl: logoUrl, darkModeUrl: darkLogoUrl } = logo;
+  const { defaultUrl: customLogo } = logo;
 
-  const customLogo = darkMode ? darkLogoUrl ?? logoUrl : logoUrl;
+  // const customLogo = darkMode ? darkLogoUrl ?? logoUrl : logoUrl;
   const defaultLogo = darkMode ? DEFAULT_DARK_LOGO : DEFAULT_LOGO;
 
   const logoSrc = customLogo ? customLogo : `${assetFolderUrl}/${defaultLogo}`;

--- a/src/core/public/chrome/ui/header/home_icon.tsx
+++ b/src/core/public/chrome/ui/header/home_icon.tsx
@@ -23,9 +23,11 @@ export const HomeIcon = ({
   applicationTitle = 'opensearch dashboards',
   useExpandedHeader = true,
 }: ChromeBranding) => {
-  const { defaultUrl: markUrl, darkModeUrl: darkMarkUrl } = mark ?? {};
+  // const { defaultUrl: markUrl, darkModeUrl: darkMarkUrl } = mark ?? {};
 
-  const customMark = darkMode ? darkMarkUrl ?? markUrl : markUrl;
+  const { defaultUrl: customMark } = mark ?? {};
+  // const customMark = darkMode ? darkMarkUrl ?? markUrl : markUrl;
+
   const defaultMark = darkMode ? DEFAULT_DARK_MARK : DEFAULT_MARK;
 
   const getIconProps = () => {

--- a/src/core/server/rendering/rendering_service.tsx
+++ b/src/core/server/rendering/rendering_service.tsx
@@ -143,7 +143,6 @@ export class RenderingService {
                   brandingAssignment.logoDefault,
                   brandingAssignment.logoDarkmode
                 ),
-                darkModeUrl: brandingAssignment.logoDarkmode,
               },
               mark: {
                 defaultUrl: this.darkModeLogic(
@@ -151,12 +150,10 @@ export class RenderingService {
                   brandingAssignment.markDefault,
                   brandingAssignment.markDarkmode
                 ),
-                darkModeUrl: brandingAssignment.markDarkmode,
               },
               loadingLogo: {
                 defaultUrl: this.loadingLogoLogic(darkMode, brandingAssignment).loadinglogo,
                 loadingBar: this.loadingLogoLogic(darkMode, brandingAssignment).loadBar,
-                darkModeUrl: brandingAssignment.loadingLogoDarkmode,
               },
               faviconUrl: brandingAssignment.favicon,
               applicationTitle: brandingAssignment.applicationTitle,

--- a/src/core/server/rendering/types.ts
+++ b/src/core/server/rendering/types.ts
@@ -151,3 +151,15 @@ export interface BrandingAssignment {
   applicationTitle?: string;
   useExpandedHeader?: boolean;
 }
+
+export interface BrandingAssignmentWithoutValidation {
+  logoDefaultConfig: string;
+  logoDarkmodeConfig: string;
+  markDefaultConfig: string;
+  markDarkmodeConfig: string;
+  loadingLogoDefaultConfig: string;
+  loadingLogoDarkmodeConfig: string;
+  faviconConfig: string;
+  applicationTitleConfig: string;
+  useExpandedHeader: boolean;
+}

--- a/src/core/server/rendering/views/template.tsx
+++ b/src/core/server/rendering/views/template.tsx
@@ -94,10 +94,13 @@ export const Template: FunctionComponent<Props> = ({
     </svg>
   );
 
-  const loadingLogoDefault = injectedMetadata.branding.loadingLogo?.defaultUrl;
+  /* const loadingLogoDefault = injectedMetadata.branding.loadingLogo?.defaultUrl;
   const loadingLogoDarkMode = injectedMetadata.branding.loadingLogo?.darkModeUrl;
   const markDefault = injectedMetadata.branding.mark?.defaultUrl;
-  const markDarkMode = injectedMetadata.branding.mark?.darkModeUrl;
+  const markDarkMode = injectedMetadata.branding.mark?.darkModeUrl;*/
+
+  const loadingurl = injectedMetadata.branding.loadingLogo?.defaultUrl;
+  const loadingbar = injectedMetadata.branding.loadingLogo?.loadingBar;
   const favicon = injectedMetadata.branding.faviconUrl;
   const applicationTitle = injectedMetadata.branding.applicationTitle;
 
@@ -109,9 +112,9 @@ export const Template: FunctionComponent<Props> = ({
    *
    * @returns a valid custom URL or undefined if no valid URL is provided
    */
-  const customLoadingLogoDefaultMode = () => {
+  /* const customLoadingLogoDefaultMode = () => {
     return loadingLogoDefault ?? markDefault ?? undefined;
-  };
+  };*/
 
   /**
    * Use branding configurations to check which URL to use for rendering
@@ -121,18 +124,18 @@ export const Template: FunctionComponent<Props> = ({
    *
    * @returns a valid custom URL or undefined if no valid URL is provided
    */
-  const customLoadingLogoDarkMode = () => {
+  /* const customLoadingLogoDarkMode = () => {
     return loadingLogoDarkMode ?? loadingLogoDefault ?? markDarkMode ?? markDefault ?? undefined;
-  };
+  };*/
 
   /**
    * Render custom loading logo for both default mode and dark mode
    *
    * @returns a valid custom loading logo URL, or undefined
    */
-  const customLoadingLogo = () => {
+  /* const customLoadingLogo = () => {
     return darkMode ? customLoadingLogoDarkMode() : customLoadingLogoDefaultMode();
-  };
+  };*/
 
   /**
    * Check if a horizontal loading is needed to be rendered.
@@ -144,7 +147,8 @@ export const Template: FunctionComponent<Props> = ({
    * @returns a loading bar component or no loading bar component
    */
   const renderBrandingEnabledOrDisabledLoadingBar = () => {
-    if (customLoadingLogo() && !loadingLogoDefault) {
+    if (loadingbar) {
+      // console.log('yes loading bar');
       return <div className="osdProgress" />;
     }
   };
@@ -157,10 +161,10 @@ export const Template: FunctionComponent<Props> = ({
    * @returns a image component with custom logo URL, or the default opensearch logo spinner
    */
   const renderBrandingEnabledOrDisabledLoadingLogo = () => {
-    if (customLoadingLogo()) {
+    if (loadingurl) {
       return (
         <div className="loadingLogoContainer">
-          <img className="loadingLogo" src={customLoadingLogo()} alt={applicationTitle + ' logo'} />
+          <img className="loadingLogo" src={loadingurl} alt={applicationTitle + ' logo'} />
         </div>
       );
     }

--- a/src/core/types/custom_branding.ts
+++ b/src/core/types/custom_branding.ts
@@ -51,6 +51,7 @@ export interface Branding {
   /** Loading logo that will be rendered on the loading page */
   loadingLogo?: {
     defaultUrl?: string;
+    loadingBar?: boolean;
     darkModeUrl?: string;
   };
   /** Custom favicon that will be rendered on the browser tab */

--- a/src/plugins/home/public/application/components/solutions_section/solution_title.tsx
+++ b/src/plugins/home/public/application/components/solutions_section/solution_title.tsx
@@ -64,9 +64,9 @@ interface Props {
  * @param {HomePluginBranding} - pass in custom branding configurations
  * @returns a valid custom URL or undefined if no valid URL is provided
  */
-const customHomeLogoDefaultMode = (branding: HomePluginBranding) => {
+/* const customHomeLogoDefaultMode = (branding: HomePluginBranding) => {
   return branding.mark?.defaultUrl ?? undefined;
-};
+};*/
 
 /**
  * Use branding configurations to check which URL to use for rendering
@@ -78,9 +78,9 @@ const customHomeLogoDefaultMode = (branding: HomePluginBranding) => {
  * @param {HomePluginBranding} - pass in custom branding configurations
  * @returns {string|undefined} a valid custom URL or undefined if no valid URL is provided
  */
-const customHomeLogoDarkMode = (branding: HomePluginBranding) => {
+/* const customHomeLogoDarkMode = (branding: HomePluginBranding) => {
   return branding.mark?.darkModeUrl ?? branding.mark?.defaultUrl ?? undefined;
-};
+};*/
 
 /**
  * Render custom home logo for both default mode and dark mode
@@ -88,9 +88,9 @@ const customHomeLogoDarkMode = (branding: HomePluginBranding) => {
  * @param {HomePluginBranding} - pass in custom branding configurations
  * @returns {string|undefined} a valid custom loading logo URL, or undefined
  */
-const customHomeLogo = (branding: HomePluginBranding) => {
+/* const customHomeLogo = (branding: HomePluginBranding) => {
   return branding.darkMode ? customHomeLogoDarkMode(branding) : customHomeLogoDefaultMode(branding);
-};
+};*/
 
 /**
  * Check if we render a custom home logo or the default opensearch spinner.
@@ -101,16 +101,16 @@ const customHomeLogo = (branding: HomePluginBranding) => {
  * @returns a image component with custom logo URL, or the default opensearch logo
  */
 const renderBrandingEnabledOrDisabledLogo = (branding: HomePluginBranding) => {
-  const customLogo = customHomeLogo(branding);
-  if (customLogo) {
+  // const customLogo = customHomeLogo(branding);
+  if (branding.mark?.defaultUrl) {
     return (
       <div className="homSolutionPanel__customIcon">
         <img
           className="homSolutionPanel__customIconContainer"
           data-test-subj="dashboardCustomLogo"
-          data-test-image-url={customLogo}
+          data-test-image-url={branding.mark?.defaultUrl}
           alt={branding.applicationTitle + ' logo'}
-          src={customLogo}
+          src={branding.mark?.defaultUrl}
         />
       </div>
     );

--- a/src/plugins/home/public/application/components/welcome.tsx
+++ b/src/plugins/home/public/application/components/welcome.tsx
@@ -146,9 +146,10 @@ export class Welcome extends React.Component<Props> {
     }
   };
 
-  private darkMode = this.props.branding.darkMode;
+  /* private darkMode = this.props.branding.darkMode;
   private markDefault = this.props.branding.mark.defaultUrl;
-  private markDarkMode = this.props.branding.mark.darkModeUrl;
+  private markDarkMode = this.props.branding.mark.darkModeUrl;*/
+  private url = this.props.branding.mark.defaultUrl;
   private applicationTitle = this.props.branding.applicationTitle;
 
   /**
@@ -159,9 +160,9 @@ export class Welcome extends React.Component<Props> {
    *
    * @returns a valid custom URL or undefined if no valid URL is provided
    */
-  private customWelcomeLogoDefaultMode = () => {
+  /* private customWelcomeLogoDefaultMode = () => {
     return this.markDefault ?? undefined;
-  };
+  };*/
 
   /**
    * Use branding configurations to check which URL to use for rendering
@@ -172,21 +173,21 @@ export class Welcome extends React.Component<Props> {
    *
    * @returns a valid custom URL or undefined if no valid URL is provided
    */
-  private customWelcomeLogoDarkMode = () => {
+  /* private customWelcomeLogoDarkMode = () => {
     return this.markDarkMode ?? this.markDefault ?? undefined;
-  };
+  };*/
 
   /**
    * Render custom welcome logo for both default mode and dark mode
    *
    * @returns a valid custom loading logo URL, or undefined
    */
-  private customWelcomeLogo = () => {
+  /* private customWelcomeLogo = () => {
     if (this.darkMode) {
       return this.customWelcomeLogoDarkMode();
     }
     return this.customWelcomeLogoDefaultMode();
-  };
+  };*/
 
   /**
    * Check if we render a custom welcome logo or the default opensearch spinner.
@@ -196,15 +197,15 @@ export class Welcome extends React.Component<Props> {
    * @returns a image component with custom logo URL, or the default opensearch logo
    */
   private renderBrandingEnabledOrDisabledLogo = () => {
-    if (this.customWelcomeLogo()) {
+    if (this.url) {
       return (
         <div className="homWelcome__customLogoContainer">
           <img
             className="homWelcome__customLogo"
             data-test-subj="welcomeCustomLogo"
-            data-test-image-url={this.customWelcomeLogo()}
+            data-test-image-url={this.url}
             alt={this.applicationTitle + ' logo'}
-            src={this.customWelcomeLogo()}
+            src={this.url}
           />
         </div>
       );

--- a/src/plugins/opensearch_dashboards_react/public/overview_page/overview_page_header/overview_page_header.tsx
+++ b/src/plugins/opensearch_dashboards_react/public/overview_page/overview_page_header/overview_page_header.tsx
@@ -79,8 +79,8 @@ export const OverviewPageHeader: FC<Props> = ({
   const DARKMODE_OPENSEARCH_MARK = `${branding.assetFolderUrl}/opensearch_mark_dark_mode.svg`;
 
   const darkMode = branding.darkMode;
-  const markDefault = branding.mark?.defaultUrl;
-  const markDarkMode = branding.mark?.darkModeUrl;
+  const mark = branding.mark?.defaultUrl;
+  // const markDarkMode = branding.mark?.darkModeUrl;
 
   /**
    * Use branding configurations to check which URL to use for rendering
@@ -90,9 +90,9 @@ export const OverviewPageHeader: FC<Props> = ({
    *
    * @returns a valid custom URL or undefined if no valid URL is provided
    */
-  const customOverviewLogoDefaultMode = () => {
+  /* const customOverviewLogoDefaultMode = () => {
     return markDefault ?? DEFAULT_OPENSEARCH_MARK;
-  };
+  };*/
 
   /**
    * Use branding configurations to check which URL to use for rendering
@@ -103,9 +103,9 @@ export const OverviewPageHeader: FC<Props> = ({
    *
    * @returns a valid custom URL or undefined if no valid URL is provided
    */
-  const customOverviewLogoDarkMode = () => {
+  /* const customOverviewLogoDarkMode = () => {
     return markDarkMode ?? markDefault ?? DARKMODE_OPENSEARCH_MARK;
-  };
+  };*/
 
   /**
    * Render custom overview logo for both default mode and dark mode
@@ -113,7 +113,8 @@ export const OverviewPageHeader: FC<Props> = ({
    * @returns a valid custom loading logo URL, or undefined
    */
   const customOverviewLogo = () => {
-    return darkMode ? customOverviewLogoDarkMode() : customOverviewLogoDefaultMode();
+    // console.log(mark);
+    return mark ?? (darkMode ? DARKMODE_OPENSEARCH_MARK : DEFAULT_OPENSEARCH_MARK);
   };
 
   /**


### PR DESCRIPTION
### Description
This PR is a rough draft that extends rendering service to handle some of the duplication branding logic. It proves the logic working for all branding occurrences with default mode and darkmode as well as the option to add a skipvalidation config. It does not include any tests yet.

Here is one potential implementation: 
1. After researching on all the react components that takes in the custom branding configurations, one most duplicated logic is to handle darkmode and default mode. In the rendering service, we can add a function in the rendering service to handle that logic and only return and pass a single URL for the components to use.
2. Since loading logo logic is more complicated and involve more fallback mechanisms, we should add another function to handle loading logo logic separately in the rendering service. It will return one single URL and also a boolean to indicate if a loading bar should be displayed.
3. If there is no custom branding, the components will render the default opensearch logo or mark. Since the default opensearch logo/mark/loading logo are different for each branding occurrences, this logic should not be handled in the rendering service, the components would still need to handle their own.
4. Also explored the option to add in a skipvalidation config. When set to true, it will just pass in original branding configs input by user without any logging or validation.
 
### Issues Resolved
One possible implementation: Extend rendering service
Part of the design spike: https://github.com/opensearch-project/OpenSearch-Dashboards/issues/2045

 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
    - [ ] `yarn test:jest`
    - [ ] `yarn test:jest_integration`
    - [ ] `yarn test:ftr`
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff 