### PR TITLE
App data persistence of vis builder following the existing pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [Vis Builder] Fix empty workspace animation does not work in firefox ([#2853](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2853))
 - Bumped `del` version to fix MacOS race condition ([#2847](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2873))
 - [Build] Fixed "Last Access Time" not being set by `scanCopy` on Windows ([#2964](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2964))
-- [Vis Builder] global data persistence for vis builder #2896 ([#2896](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2896))
+- [Vis Builder] Add global data persistence for vis builder #2896 ([#2896](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2896))
+
 ### 🚞 Infrastructure
 
 - Add CHANGELOG.md and related workflows ([#2414](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2414))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [Vis Builder] Fix empty workspace animation does not work in firefox ([#2853](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2853))
 - Bumped `del` version to fix MacOS race condition ([#2847](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2873))
 - [Build] Fixed "Last Access Time" not being set by `scanCopy` on Windows ([#2964](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2964))
-
+- [Vis Builder] global data persistence for vis builder #2896 ([#2896](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2896))
 ### 🚞 Infrastructure
 
 - Add CHANGELOG.md and related workflows ([#2414](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2414))

--- a/package.json
+++ b/package.json
@@ -201,6 +201,7 @@
     "react-input-range": "^1.3.0",
     "react-router": "^5.2.1",
     "react-use": "^13.27.0",
+    "redux-devtools-extension": "^2.13.9",
     "redux-thunk": "^2.3.0",
     "regenerator-runtime": "^0.13.3",
     "require-in-the-middle": "^5.0.2",

--- a/src/plugins/vis_builder/public/application/app.tsx
+++ b/src/plugins/vis_builder/public/application/app.tsx
@@ -17,6 +17,7 @@ import { useOpenSearchDashboards } from '../../../opensearch_dashboards_react/pu
 import { VisBuilderServices } from '../types';
 import { syncQueryStateWithUrl } from '../../../data/public';
 import EventEmitter from 'events';
+import { useVisBuilderAppState } from './utils/use/use_vis_builder_app_state';
 
 export const VisBuilderApp = () => {
   const {
@@ -38,6 +39,7 @@ export const VisBuilderApp = () => {
     // so the global state is always preserved
   }, [query, osdUrlStateStorage, pathname]);
 
+  //const { instace } = useVisBuilderAppState
   // Render the application DOM.
   return (
     <I18nProvider>

--- a/src/plugins/vis_builder/public/application/app.tsx
+++ b/src/plugins/vis_builder/public/application/app.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { I18nProvider } from '@osd/i18n/react';
 import { EuiPage, EuiResizableContainer } from '@elastic/eui';
 import { useLocation } from 'react-router-dom';
@@ -16,6 +16,7 @@ import { RightNav } from './components/right_nav';
 import { useOpenSearchDashboards } from '../../../opensearch_dashboards_react/public';
 import { VisBuilderServices } from '../types';
 import { syncQueryStateWithUrl } from '../../../data/public';
+import EventEmitter from 'events';
 
 export const VisBuilderApp = () => {
   const {
@@ -25,6 +26,7 @@ export const VisBuilderApp = () => {
     },
   } = useOpenSearchDashboards<VisBuilderServices>();
   const { pathname } = useLocation();
+  const [eventEmitter] = useState(new EventEmitter());
 
   useEffect(() => {
     // syncs `_g` portion of url with query services
@@ -41,8 +43,8 @@ export const VisBuilderApp = () => {
     <I18nProvider>
       <DragDropProvider>
         <EuiPage className="vbLayout">
-          <TopNav />
-          <LeftNav />
+          <TopNav eventEmitter={eventEmitter}/>
+          <LeftNav eventEmitter={eventEmitter}/>
           <EuiResizableContainer className="vbLayout__resizeContainer">
             {(EuiResizablePanel, EuiResizableButton) => (
               <>

--- a/src/plugins/vis_builder/public/application/app.tsx
+++ b/src/plugins/vis_builder/public/application/app.tsx
@@ -3,17 +3,39 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React from 'react';
+import React, { useEffect } from 'react';
 import { I18nProvider } from '@osd/i18n/react';
 import { EuiPage, EuiResizableContainer } from '@elastic/eui';
+import { useLocation } from 'react-router-dom';
 import { DragDropProvider } from './utils/drag_drop/drag_drop_context';
 import { LeftNav } from './components/left_nav';
 import { TopNav } from './components/top_nav';
 import { Workspace } from './components/workspace';
 import './app.scss';
 import { RightNav } from './components/right_nav';
+import { useOpenSearchDashboards } from '../../../opensearch_dashboards_react/public';
+import { VisBuilderServices } from '../types';
+import { syncQueryStateWithUrl } from '../../../data/public';
 
 export const VisBuilderApp = () => {
+  const {
+    services: {
+      data: { query },
+      osdUrlStateStorage,
+    },
+  } = useOpenSearchDashboards<VisBuilderServices>();
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    // syncs `_g` portion of url with query services
+    const { stop } = syncQueryStateWithUrl(query, osdUrlStateStorage);
+
+    return () => stop();
+
+    // this effect should re-run when pathname is changed to preserve querystring part,
+    // so the global state is always preserved
+  }, [query, osdUrlStateStorage, pathname]);
+
   // Render the application DOM.
   return (
     <I18nProvider>

--- a/src/plugins/vis_builder/public/application/components/data_source_select.tsx
+++ b/src/plugins/vis_builder/public/application/components/data_source_select.tsx
@@ -11,7 +11,7 @@ import { useIndexPatterns } from '../utils/use';
 import { useTypedDispatch } from '../utils/state_management';
 import { setIndexPattern } from '../utils/state_management/visualization_slice';
 import { IndexPattern } from '../../../../data/public';
-import { EventEmitterProp } from '../../types';
+import { DataSourceSelectProps } from '../../types';
 
 function indexPatternEquality(A?: SearchableDropdownOption, B?: SearchableDropdownOption): boolean {
   return !A || !B ? false : A.id === B.id;
@@ -26,10 +26,9 @@ function toSearchableDropdownOption(indexPattern: IndexPattern): SearchableDropd
   };
 }
 
-export const DataSourceSelect = ({eventEmitter}: EventEmitterProp) => {
+export const DataSourceSelect = ({appState}: DataSourceSelectProps) => {
   const { indexPatterns, loading, error, selected } = useIndexPatterns();
   const dispatch = useTypedDispatch();
-
   // TODO: Should be a standard EUI component
   return (
     <SearchableDropdown
@@ -39,9 +38,7 @@ export const DataSourceSelect = ({eventEmitter}: EventEmitterProp) => {
         if (foundOption !== undefined && typeof foundOption.id === 'string') {
           dispatch(setIndexPattern(foundOption.id));
           console.log(foundOption.title, foundOption.id)
-          eventEmitter.emit('dirtyStateChange', {
-            isDirty: false,
-          });
+          appState.set(appState.getState());
         }
       }}
       prepend={i18n.translate('visBuilder.nav.dataSource.selector.title', {

--- a/src/plugins/vis_builder/public/application/components/data_source_select.tsx
+++ b/src/plugins/vis_builder/public/application/components/data_source_select.tsx
@@ -11,6 +11,7 @@ import { useIndexPatterns } from '../utils/use';
 import { useTypedDispatch } from '../utils/state_management';
 import { setIndexPattern } from '../utils/state_management/visualization_slice';
 import { IndexPattern } from '../../../../data/public';
+import { EventEmitterProp } from '../../types';
 
 function indexPatternEquality(A?: SearchableDropdownOption, B?: SearchableDropdownOption): boolean {
   return !A || !B ? false : A.id === B.id;
@@ -25,7 +26,7 @@ function toSearchableDropdownOption(indexPattern: IndexPattern): SearchableDropd
   };
 }
 
-export const DataSourceSelect = () => {
+export const DataSourceSelect = ({eventEmitter}: EventEmitterProp) => {
   const { indexPatterns, loading, error, selected } = useIndexPatterns();
   const dispatch = useTypedDispatch();
 
@@ -37,6 +38,10 @@ export const DataSourceSelect = () => {
         const foundOption = indexPatterns.filter((s) => s.id === option.id)[0];
         if (foundOption !== undefined && typeof foundOption.id === 'string') {
           dispatch(setIndexPattern(foundOption.id));
+          console.log(foundOption.title, foundOption.id)
+          eventEmitter.emit('dirtyStateChange', {
+            isDirty: false,
+          });
         }
       }}
       prepend={i18n.translate('visBuilder.nav.dataSource.selector.title', {

--- a/src/plugins/vis_builder/public/application/components/data_tab/config_panel.tsx
+++ b/src/plugins/vis_builder/public/application/components/data_tab/config_panel.tsx
@@ -10,10 +10,10 @@ import { useTypedSelector } from '../../utils/state_management';
 import './config_panel.scss';
 import { mapSchemaToAggPanel } from './schema_to_dropbox';
 import { SecondaryPanel } from './secondary_panel';
-import EventEmitter from 'events';
-import { EventEmitterProp } from '../../../types';
+// import EventEmitter from 'events';
+import { ConfigPanelProps } from '../../../types';
 
-export function ConfigPanel({eventEmitter}: EventEmitterProp) {
+export function ConfigPanel({appState}: ConfigPanelProps) {
   const vizType = useVisualizationType();
   const editingState = useTypedSelector(
     (state) => state.visualization.activeVisualization?.draftAgg
@@ -27,7 +27,7 @@ export function ConfigPanel({eventEmitter}: EventEmitterProp) {
   return (
     <EuiForm className={`vbConfig ${editingState ? 'showSecondary' : ''}`}>
       <div className="vbConfig__section">{mainPanel}</div>
-      <SecondaryPanel eventEmitter={eventEmitter}/>
+      <SecondaryPanel appState={appState}/>
     </EuiForm>
   );
 }

--- a/src/plugins/vis_builder/public/application/components/data_tab/config_panel.tsx
+++ b/src/plugins/vis_builder/public/application/components/data_tab/config_panel.tsx
@@ -10,8 +10,10 @@ import { useTypedSelector } from '../../utils/state_management';
 import './config_panel.scss';
 import { mapSchemaToAggPanel } from './schema_to_dropbox';
 import { SecondaryPanel } from './secondary_panel';
+import EventEmitter from 'events';
+import { EventEmitterProp } from '../../../types';
 
-export function ConfigPanel() {
+export function ConfigPanel({eventEmitter}: EventEmitterProp) {
   const vizType = useVisualizationType();
   const editingState = useTypedSelector(
     (state) => state.visualization.activeVisualization?.draftAgg
@@ -25,7 +27,7 @@ export function ConfigPanel() {
   return (
     <EuiForm className={`vbConfig ${editingState ? 'showSecondary' : ''}`}>
       <div className="vbConfig__section">{mainPanel}</div>
-      <SecondaryPanel />
+      <SecondaryPanel eventEmitter={eventEmitter}/>
     </EuiForm>
   );
 }

--- a/src/plugins/vis_builder/public/application/components/data_tab/index.tsx
+++ b/src/plugins/vis_builder/public/application/components/data_tab/index.tsx
@@ -8,14 +8,16 @@ import { FieldSelector } from './field_selector';
 
 import './index.scss';
 import { ConfigPanel } from './config_panel';
+import { EventEmitter } from 'stream';
+import { EventEmitterProp } from '../../../types';
 
 export const DATA_TAB_ID = 'data_tab';
 
-export const DataTab = () => {
+export const DataTab = ({eventEmitter}: EventEmitterProp) => {
   return (
     <div className="vbDataTab">
       <FieldSelector />
-      <ConfigPanel />
+      <ConfigPanel eventEmitter={eventEmitter}/>
     </div>
   );
 };

--- a/src/plugins/vis_builder/public/application/components/data_tab/index.tsx
+++ b/src/plugins/vis_builder/public/application/components/data_tab/index.tsx
@@ -8,16 +8,16 @@ import { FieldSelector } from './field_selector';
 
 import './index.scss';
 import { ConfigPanel } from './config_panel';
-import { EventEmitter } from 'stream';
-import { EventEmitterProp } from '../../../types';
+// import { EventEmitter } from 'stream';
+import { DataTabProps, EventEmitterProp } from '../../../types';
 
 export const DATA_TAB_ID = 'data_tab';
 
-export const DataTab = ({eventEmitter}: EventEmitterProp) => {
+export const DataTab = ({appState}: DataTabProps) => {
   return (
     <div className="vbDataTab">
       <FieldSelector />
-      <ConfigPanel eventEmitter={eventEmitter}/>
+      <ConfigPanel appState={appState}/>
     </div>
   );
 };

--- a/src/plugins/vis_builder/public/application/components/data_tab/secondary_panel.tsx
+++ b/src/plugins/vis_builder/public/application/components/data_tab/secondary_panel.tsx
@@ -11,14 +11,15 @@ import { DefaultEditorAggParams } from '../../../../../vis_default_editor/public
 import { Title } from './title';
 import { useIndexPatterns, useVisualizationType } from '../../utils/use';
 import { useOpenSearchDashboards } from '../../../../../opensearch_dashboards_react/public';
-import { VisBuilderServices } from '../../../types';
+import { EventEmitterProp, VisBuilderServices } from '../../../types';
 import { AggParam, IAggType, IFieldParamType } from '../../../../../data/public';
 import { saveDraftAgg, editDraftAgg } from '../../utils/state_management/visualization_slice';
 import { setValidity } from '../../utils/state_management/metadata_slice';
+import { EventEmitter } from 'events';
 
 const EDITOR_KEY = 'CONFIG_PANEL';
 
-export function SecondaryPanel() {
+export function SecondaryPanel({eventEmitter}: EventEmitterProp) {
   const { draftAgg, aggConfigParams } = useTypedSelector(
     (state) => state.visualization.activeVisualization!
   );
@@ -65,6 +66,9 @@ export function SecondaryPanel() {
 
   const closeMenu = useCallback(() => {
     dispatch(editDraftAgg(undefined));
+    eventEmitter.emit('dirtyStateChange', {
+      isDirty: false,
+    });
   }, [dispatch]);
 
   const handleSetValid = useCallback(
@@ -120,6 +124,9 @@ export function SecondaryPanel() {
           ): void {
             aggConfig.params[paramName] = value;
             dispatch(editDraftAgg(aggConfig.serialize()));
+            eventEmitter.emit('dirtyStateChange', {
+              isDirty: false,
+            });
           }}
           onAggTypeChange={function (aggId: string, aggType: IAggType): void {
             aggConfig.type = aggType;
@@ -138,6 +145,9 @@ export function SecondaryPanel() {
             }
 
             dispatch(editDraftAgg(aggConfig.serialize()));
+            eventEmitter.emit('dirtyStateChange', {
+              isDirty: false,
+            });
           }}
         />
       )}

--- a/src/plugins/vis_builder/public/application/components/data_tab/secondary_panel.tsx
+++ b/src/plugins/vis_builder/public/application/components/data_tab/secondary_panel.tsx
@@ -11,15 +11,15 @@ import { DefaultEditorAggParams } from '../../../../../vis_default_editor/public
 import { Title } from './title';
 import { useIndexPatterns, useVisualizationType } from '../../utils/use';
 import { useOpenSearchDashboards } from '../../../../../opensearch_dashboards_react/public';
-import { EventEmitterProp, VisBuilderServices } from '../../../types';
+import { ConfigPanelProps, EventEmitterProp, VisBuilderServices } from '../../../types';
 import { AggParam, IAggType, IFieldParamType } from '../../../../../data/public';
 import { saveDraftAgg, editDraftAgg } from '../../utils/state_management/visualization_slice';
 import { setValidity } from '../../utils/state_management/metadata_slice';
-import { EventEmitter } from 'events';
+// import { EventEmitter } from 'events';
 
 const EDITOR_KEY = 'CONFIG_PANEL';
 
-export function SecondaryPanel({eventEmitter}: EventEmitterProp) {
+export function SecondaryPanel({appState}: ConfigPanelProps ) {
   const { draftAgg, aggConfigParams } = useTypedSelector(
     (state) => state.visualization.activeVisualization!
   );
@@ -66,9 +66,9 @@ export function SecondaryPanel({eventEmitter}: EventEmitterProp) {
 
   const closeMenu = useCallback(() => {
     dispatch(editDraftAgg(undefined));
-    eventEmitter.emit('dirtyStateChange', {
-      isDirty: false,
-    });
+    // eventEmitter.emit('dirtyStateChange', {
+    //   isDirty: false,
+    // });
   }, [dispatch]);
 
   const handleSetValid = useCallback(
@@ -124,9 +124,9 @@ export function SecondaryPanel({eventEmitter}: EventEmitterProp) {
           ): void {
             aggConfig.params[paramName] = value;
             dispatch(editDraftAgg(aggConfig.serialize()));
-            eventEmitter.emit('dirtyStateChange', {
-              isDirty: false,
-            });
+            // eventEmitter.emit('dirtyStateChange', {
+            //   isDirty: false,
+            // });
           }}
           onAggTypeChange={function (aggId: string, aggType: IAggType): void {
             aggConfig.type = aggType;
@@ -145,9 +145,9 @@ export function SecondaryPanel({eventEmitter}: EventEmitterProp) {
             }
 
             dispatch(editDraftAgg(aggConfig.serialize()));
-            eventEmitter.emit('dirtyStateChange', {
-              isDirty: false,
-            });
+            // eventEmitter.emit('dirtyStateChange', {
+            //   isDirty: false,
+            // });
           }}
         />
       )}

--- a/src/plugins/vis_builder/public/application/components/left_nav.tsx
+++ b/src/plugins/vis_builder/public/application/components/left_nav.tsx
@@ -7,15 +7,33 @@ import React from 'react';
 import './side_nav.scss';
 import { DataSourceSelect } from './data_source_select';
 import { DataTab } from './data_tab';
-import { EventEmitterProp } from '../../types';
+import { EventEmitterProp, LeftNavProps, VisBuilderServices } from '../../types';
+import { useOpenSearchDashboards } from '../../../../opensearch_dashboards_react/public';
+import { useTypedSelector, useTypedDispatch } from '../utils/state_management';
+import { useSavedVisBuilderVis } from '../utils/use';
+import { useCanSave } from '../utils/use/use_can_save';
+import { useVisBuilderAppState } from '../utils/use/use_vis_builder_app_state';
 
 export const LeftNav = ({eventEmitter}: EventEmitterProp) => {
+  const { services } = useOpenSearchDashboards<VisBuilderServices>();
+  const rootState = useTypedSelector((state) => state);
+  const dispatch = useTypedDispatch();
+
+  const savedVisBuilderVis = useSavedVisBuilderVis(eventEmitter, visualizationIdFromUrl);
+  console.log("save vis builder vis", savedVisBuilderVis)
+  const appState = useVisBuilderAppState(
+    services,
+    eventEmitter,
+    savedVisBuilderVis,
+    rootState
+  )
+  
   return (
     <section className="vbSidenav left">
       <div className="vbDatasourceSelect vbSidenav__header">
-        <DataSourceSelect eventEmitter={eventEmitter}/>
+        <DataSourceSelect appState={appState!}/>
       </div>
-      <DataTab key="containerName" eventEmitter={eventEmitter}/>
+      <DataTab key="containerName" appState={appState!}/>
     </section>
   );
 };

--- a/src/plugins/vis_builder/public/application/components/left_nav.tsx
+++ b/src/plugins/vis_builder/public/application/components/left_nav.tsx
@@ -7,14 +7,15 @@ import React from 'react';
 import './side_nav.scss';
 import { DataSourceSelect } from './data_source_select';
 import { DataTab } from './data_tab';
+import { EventEmitterProp } from '../../types';
 
-export const LeftNav = () => {
+export const LeftNav = ({eventEmitter}: EventEmitterProp) => {
   return (
     <section className="vbSidenav left">
       <div className="vbDatasourceSelect vbSidenav__header">
-        <DataSourceSelect />
+        <DataSourceSelect eventEmitter={eventEmitter}/>
       </div>
-      <DataTab key="containerName" />
+      <DataTab key="containerName" eventEmitter={eventEmitter}/>
     </section>
   );
 };

--- a/src/plugins/vis_builder/public/application/components/right_nav.tsx
+++ b/src/plugins/vis_builder/public/application/components/right_nav.tsx
@@ -16,8 +16,9 @@ import { FormattedMessage } from '@osd/i18n/react';
 import { useVisualizationType } from '../utils/use';
 import './side_nav.scss';
 import { useOpenSearchDashboards } from '../../../../opensearch_dashboards_react/public';
-import { VisBuilderServices } from '../../types';
+import { EventEmitterProp, VisBuilderServices } from '../../types';
 import { setActiveVisualization, useTypedDispatch } from '../utils/state_management';
+import { EventEmitter } from 'stream';
 
 export const RightNav = () => {
   const [newVisType, setNewVisType] = useState<string>();

--- a/src/plugins/vis_builder/public/application/components/top_nav.tsx
+++ b/src/plugins/vis_builder/public/application/components/top_nav.tsx
@@ -36,7 +36,7 @@ export const TopNav = ({eventEmitter}: EventEmitterProp) => {
   //const [eventEmitter] = useState(new EventEmitter());
 
   const saveDisabledReason = useCanSave();
-  const savedVisBuilderVis = useSavedVisBuilderVis(eventEmitter, visualizationIdFromUrl);
+  const savedVisBuilderVis = useSavedVisBuilderVis(visualizationIdFromUrl);
   console.log("save vis builder vis", savedVisBuilderVis)
   const appState = useVisBuilderAppState(
     services,

--- a/src/plugins/vis_builder/public/application/components/top_nav.tsx
+++ b/src/plugins/vis_builder/public/application/components/top_nav.tsx
@@ -18,6 +18,8 @@ import { setEditorState } from '../utils/state_management/metadata_slice';
 import { useCanSave } from '../utils/use/use_can_save';
 import { saveStateToSavedObject } from '../../saved_visualizations/transforms';
 import { TopNavMenuData } from '../../../../navigation/public';
+import EventEmitter from 'events';
+import { useVisBuilderAppState } from '../utils/use/use_vis_builder_app_state';
 
 export const TopNav = () => {
   // id will only be set for the edit route
@@ -31,9 +33,16 @@ export const TopNav = () => {
   } = services;
   const rootState = useTypedSelector((state) => state);
   const dispatch = useTypedDispatch();
+  const [eventEmitter] = useState(new EventEmitter());
 
   const saveDisabledReason = useCanSave();
   const savedVisBuilderVis = useSavedVisBuilderVis(visualizationIdFromUrl);
+  const appState = useVisBuilderAppState(
+    services,
+    eventEmitter,
+    savedVisBuilderVis
+  )
+  console.log("save vis builder vis", savedVisBuilderVis)
   const { selected: indexPattern } = useIndexPatterns();
   const [config, setConfig] = useState<TopNavMenuData[] | undefined>();
   const originatingApp = useTypedSelector((state) => {

--- a/src/plugins/vis_builder/public/application/components/top_nav.tsx
+++ b/src/plugins/vis_builder/public/application/components/top_nav.tsx
@@ -9,7 +9,7 @@ import { useUnmount } from 'react-use';
 import { PLUGIN_ID } from '../../../common';
 import { useOpenSearchDashboards } from '../../../../opensearch_dashboards_react/public';
 import { getTopNavConfig } from '../utils/get_top_nav_config';
-import { VisBuilderServices } from '../../types';
+import { EventEmitterProp, VisBuilderServices } from '../../types';
 
 import './top_nav.scss';
 import { useIndexPatterns, useSavedVisBuilderVis } from '../utils/use';
@@ -21,7 +21,7 @@ import { TopNavMenuData } from '../../../../navigation/public';
 import EventEmitter from 'events';
 import { useVisBuilderAppState } from '../utils/use/use_vis_builder_app_state';
 
-export const TopNav = () => {
+export const TopNav = ({eventEmitter}: EventEmitterProp) => {
   // id will only be set for the edit route
   const { id: visualizationIdFromUrl } = useParams<{ id: string }>();
   const { services } = useOpenSearchDashboards<VisBuilderServices>();
@@ -33,17 +33,18 @@ export const TopNav = () => {
   } = services;
   const rootState = useTypedSelector((state) => state);
   const dispatch = useTypedDispatch();
-  const [eventEmitter] = useState(new EventEmitter());
+  //const [eventEmitter] = useState(new EventEmitter());
 
   const saveDisabledReason = useCanSave();
-  const savedVisBuilderVis = useSavedVisBuilderVis(visualizationIdFromUrl);
+  const savedVisBuilderVis = useSavedVisBuilderVis(eventEmitter, visualizationIdFromUrl);
   console.log("save vis builder vis", savedVisBuilderVis)
-  /*const appState = useVisBuilderAppState(
+  const appState = useVisBuilderAppState(
     services,
     eventEmitter,
-    savedVisBuilderVis
+    savedVisBuilderVis,
+    rootState
   )
-  console.log("vis builder appstate", appState)*/
+  console.log("vis builder appstate", appState?.getState())
   const { selected: indexPattern } = useIndexPatterns();
   const [config, setConfig] = useState<TopNavMenuData[] | undefined>();
   const originatingApp = useTypedSelector((state) => {

--- a/src/plugins/vis_builder/public/application/components/top_nav.tsx
+++ b/src/plugins/vis_builder/public/application/components/top_nav.tsx
@@ -37,12 +37,13 @@ export const TopNav = () => {
 
   const saveDisabledReason = useCanSave();
   const savedVisBuilderVis = useSavedVisBuilderVis(visualizationIdFromUrl);
-  const appState = useVisBuilderAppState(
+  console.log("save vis builder vis", savedVisBuilderVis)
+  /*const appState = useVisBuilderAppState(
     services,
     eventEmitter,
     savedVisBuilderVis
   )
-  console.log("save vis builder vis", savedVisBuilderVis)
+  console.log("vis builder appstate", appState)*/
   const { selected: indexPattern } = useIndexPatterns();
   const [config, setConfig] = useState<TopNavMenuData[] | undefined>();
   const originatingApp = useTypedSelector((state) => {

--- a/src/plugins/vis_builder/public/application/components/top_nav.tsx
+++ b/src/plugins/vis_builder/public/application/components/top_nav.tsx
@@ -36,6 +36,9 @@ export const TopNav = () => {
   const savedVisBuilderVis = useSavedVisBuilderVis(visualizationIdFromUrl);
   const { selected: indexPattern } = useIndexPatterns();
   const [config, setConfig] = useState<TopNavMenuData[] | undefined>();
+  const originatingApp = useTypedSelector((state) => {
+    return state.metadata.originatingApp;
+  });
 
   useEffect(() => {
     const getConfig = () => {
@@ -47,6 +50,7 @@ export const TopNav = () => {
           savedVisBuilderVis: saveStateToSavedObject(savedVisBuilderVis, rootState, indexPattern),
           saveDisabledReason,
           dispatch,
+          originatingApp,
         },
         services
       );
@@ -61,6 +65,7 @@ export const TopNav = () => {
     saveDisabledReason,
     dispatch,
     indexPattern,
+    originatingApp,
   ]);
 
   // reset validity before component destroyed

--- a/src/plugins/vis_builder/public/application/index.tsx
+++ b/src/plugins/vis_builder/public/application/index.tsx
@@ -17,7 +17,7 @@ import { EDIT_PATH } from '../../common';
 export const renderApp = (
   { element, history }: AppMountParameters,
   services: VisBuilderServices,
-  store: Store
+  store: Store,
 ) => {
   ReactDOM.render(
     <Router history={history}>

--- a/src/plugins/vis_builder/public/application/utils/create_vis_builder_app_state.ts
+++ b/src/plugins/vis_builder/public/application/utils/create_vis_builder_app_state.ts
@@ -35,7 +35,7 @@ import {
   syncState,
   IOsdUrlStateStorage,
 } from '../../../../opensearch_dashboards_utils/public';
-import { PureVisState, VisBuilderAppState, VisBuilderAppStateTransitions } from '../../types'
+import { VisBuilderAppState, VisBuilderAppStateTransitions } from '../../types'
 
 const STATE_STORAGE_KEY = '_a';
 
@@ -44,28 +44,16 @@ interface Arguments {
   stateDefaults: VisBuilderAppState;
 }
 
-function toObject(state: PureVisState): PureVisState {
+/*function toObject(state: PureVisState): PureVisState {
   return omitBy(state, (value, key: string) => {
     return key.charAt(0) === '$' || key.charAt(0) === '_' || isFunction(value);
   }) as PureVisState;
-}
+}*/
 
 const pureTransitions = {
   set: (state) => (prop, value) => ({ ...state, [prop]: value }),
-  setVis: (state) => (vis) => ({
-    ...state,
-    vis: {
-      ...state.vis,
-      ...vis,
-    },
-  }),
-  unlinkSavedSearch: (state) => ({ query, parentFilters = [] }) => ({
-    ...state,
-    query: query || state.query,
-    filters: union(state.filters, parentFilters),
-    linked: false,
-  }),
-  updateVisState: (state) => (newVisState) => ({ ...state, vis: toObject(newVisState) }),
+  updateVisState: (state) => (newVisState) => ({ ...state, visualizationState: newVisState }),
+  updateStyleState: (state) => (newStyleState) => ({ ...state, styleState: newStyleState }),
   updateSavedQuery: (state) => (savedQueryId) => {
     const updatedState = {
       ...state,

--- a/src/plugins/vis_builder/public/application/utils/create_vis_builder_app_state.ts
+++ b/src/plugins/vis_builder/public/application/utils/create_vis_builder_app_state.ts
@@ -1,0 +1,117 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { isFunction, omitBy, union } from 'lodash';
+
+import {
+  createStateContainer,
+  syncState,
+  IOsdUrlStateStorage,
+} from '../../../../opensearch_dashboards_utils/public';
+import { PureVisState, VisBuilderAppState, VisBuilderAppStateTransitions } from '../../types'
+
+const STATE_STORAGE_KEY = '_a';
+
+interface Arguments {
+  osdUrlStateStorage: IOsdUrlStateStorage;
+  stateDefaults: VisBuilderAppState;
+}
+
+function toObject(state: PureVisState): PureVisState {
+  return omitBy(state, (value, key: string) => {
+    return key.charAt(0) === '$' || key.charAt(0) === '_' || isFunction(value);
+  }) as PureVisState;
+}
+
+const pureTransitions = {
+  set: (state) => (prop, value) => ({ ...state, [prop]: value }),
+  setVis: (state) => (vis) => ({
+    ...state,
+    vis: {
+      ...state.vis,
+      ...vis,
+    },
+  }),
+  unlinkSavedSearch: (state) => ({ query, parentFilters = [] }) => ({
+    ...state,
+    query: query || state.query,
+    filters: union(state.filters, parentFilters),
+    linked: false,
+  }),
+  updateVisState: (state) => (newVisState) => ({ ...state, vis: toObject(newVisState) }),
+  updateSavedQuery: (state) => (savedQueryId) => {
+    const updatedState = {
+      ...state,
+      savedQuery: savedQueryId,
+    };
+
+    if (!savedQueryId) {
+      delete updatedState.savedQuery;
+    }
+
+    return updatedState;
+  },
+} as VisBuilderAppStateTransitions;
+
+export function createVisBuilderAppState({ stateDefaults, osdUrlStateStorage }: Arguments) {
+  const urlState = osdUrlStateStorage.get<VisBuilderAppState>(STATE_STORAGE_KEY);
+  const initialState = urlState ?? stateDefaults;
+
+  /*
+     make sure url ('_a') matches initial state
+     Initializing appState does two things - first it translates the defaults into AppState,
+     second it updates appState based on the url (the url trumps the defaults). This means if
+     we update the state format at all and want to handle BWC, we must not only migrate the
+     data stored with saved vis, but also any old state in the url.
+   */
+
+  osdUrlStateStorage.set(STATE_STORAGE_KEY, initialState, { replace: true });
+
+  const stateContainer = createStateContainer<VisBuilderAppState, VisBuilderAppStateTransitions>(
+    initialState,
+    pureTransitions
+  );
+  const { start: startStateSync, stop: stopStateSync } = syncState({
+    storageKey: STATE_STORAGE_KEY,
+    stateContainer: {
+      ...stateContainer,
+      set: (state) => {
+        if (state) {
+          // syncState utils requires to handle incoming "null" value
+          stateContainer.set(state);
+        }
+      },
+    },
+    stateStorage: osdUrlStateStorage,
+  });
+  // start syncing the appState with the ('_a') url
+  startStateSync();
+  return { stateContainer, stopStateSync };
+}

--- a/src/plugins/vis_builder/public/application/utils/get_top_nav_config.tsx
+++ b/src/plugins/vis_builder/public/application/utils/get_top_nav_config.tsx
@@ -46,7 +46,7 @@ export interface TopNavConfigParams {
   savedVisBuilderVis: VisBuilderVisSavedObject;
   saveDisabledReason?: string;
   dispatch: AppDispatch;
-  originatingApp: string | undefined;
+  originatingApp?: string;
 }
 
 export const getTopNavConfig = (

--- a/src/plugins/vis_builder/public/application/utils/get_top_nav_config.tsx
+++ b/src/plugins/vis_builder/public/application/utils/get_top_nav_config.tsx
@@ -46,22 +46,24 @@ export interface TopNavConfigParams {
   savedVisBuilderVis: VisBuilderVisSavedObject;
   saveDisabledReason?: string;
   dispatch: AppDispatch;
+  originatingApp: string | undefined;
 }
 
 export const getTopNavConfig = (
-  { visualizationIdFromUrl, savedVisBuilderVis, saveDisabledReason, dispatch }: TopNavConfigParams,
+  {
+    visualizationIdFromUrl,
+    savedVisBuilderVis,
+    saveDisabledReason,
+    dispatch,
+    originatingApp,
+  }: TopNavConfigParams,
   services: VisBuilderServices
 ) => {
   const {
     i18n: { Context: I18nContext },
     embeddable,
-    scopedHistory,
   } = services;
 
-  const { originatingApp, embeddableId } =
-    embeddable
-      .getStateTransfer(scopedHistory)
-      .getIncomingEditorState({ keysToRemoveAfterFetch: ['id', 'input'] }) || {};
   const stateTransfer = embeddable.getStateTransfer();
 
   const topNavConfig: TopNavMenuData[] = [
@@ -105,7 +107,7 @@ export const getTopNavConfig = (
         showSaveModal(saveModal, I18nContext);
       },
     },
-    ...(originatingApp && ((savedVisBuilderVis && savedVisBuilderVis.id) || embeddableId)
+    ...(originatingApp && savedVisBuilderVis && savedVisBuilderVis.id
       ? [
           {
             id: 'saveAndReturn',

--- a/src/plugins/vis_builder/public/application/utils/get_vis_builder_editor_state.ts
+++ b/src/plugins/vis_builder/public/application/utils/get_vis_builder_editor_state.ts
@@ -1,31 +1,28 @@
-import { SavedObject } from '../../../../../core/types';
+import { CombinedState } from 'redux';
 import { Filter } from '../../../../data/public';
 import { VisBuilderServices } from '../../types';
-import { useTypedSelector } from '../utils/state_management';
+import { useTypedSelector, VisualizationState } from '../utils/state_management';
+import { MetadataState } from './state_management/metadata_slice';
 
 export const getDefaultQuery = ({ data }: VisBuilderServices) => {
     return data.query.queryString.getDefaultQuery();
   };
 
-export const getVisBuilderFields = () => {
-    return {
-        id: instance
-    }
-}
-
-export const visBuilderStateToEditorState = (
+export const visBuilderEditorState = (
     instance,
-    services: VisBuilderServices
+    services: VisBuilderServices,
+    rootState: CombinedState<{
+        style: any;
+        visualization: VisualizationState;
+        metadata: MetadataState;
+    }>
 ) => {
-    const savedFieldsFromStore = {
-        id: instance.id,
-        title: instance.title,
-        description: instance.description,
-        visBuilderState: {
-            title: instance.title
-        }
-    }
+    //const visualizationState = useTypedSelector((state) => state.visualization)
+    //const styleState = useTypedSelector((state)=>state.style)
+
     return {
+        visualizationState: rootState.visualization,
+        styleState: rootState.style,
         query: instance.searchSource?.getOwnField('query') || getDefaultQuery(services),
         filters: (instance.searchSource?.getOwnField('filter') as Filter[]) || [],
     }

--- a/src/plugins/vis_builder/public/application/utils/get_vis_builder_editor_state.ts
+++ b/src/plugins/vis_builder/public/application/utils/get_vis_builder_editor_state.ts
@@ -1,0 +1,18 @@
+import { SavedObject } from '../../../../../core/types';
+import { Filter } from '../../../../data/public';
+import { VisBuilderServices } from '../../types';
+import { useTypedSelector } from '../utils/state_management';
+
+export const getDefaultQuery = ({ data }: VisBuilderServices) => {
+    return data.query.queryString.getDefaultQuery();
+  };
+
+export const visBuilderStateToEditorState = (
+    instance,
+    services: VisBuilderServices
+) => {
+    return {
+        query: instance.searchSource?.getOwnField('query') || getDefaultQuery(services),
+        filters: (instance.searchSource?.getOwnField('filter') as Filter[]) || [],
+    }
+}

--- a/src/plugins/vis_builder/public/application/utils/get_vis_builder_editor_state.ts
+++ b/src/plugins/vis_builder/public/application/utils/get_vis_builder_editor_state.ts
@@ -7,10 +7,24 @@ export const getDefaultQuery = ({ data }: VisBuilderServices) => {
     return data.query.queryString.getDefaultQuery();
   };
 
+export const getVisBuilderFields = () => {
+    return {
+        id: instance
+    }
+}
+
 export const visBuilderStateToEditorState = (
     instance,
     services: VisBuilderServices
 ) => {
+    const savedFieldsFromStore = {
+        id: instance.id,
+        title: instance.title,
+        description: instance.description,
+        visBuilderState: {
+            title: instance.title
+        }
+    }
     return {
         query: instance.searchSource?.getOwnField('query') || getDefaultQuery(services),
         filters: (instance.searchSource?.getOwnField('filter') as Filter[]) || [],

--- a/src/plugins/vis_builder/public/application/utils/state_management/metadata_slice.ts
+++ b/src/plugins/vis_builder/public/application/utils/state_management/metadata_slice.ts
@@ -21,11 +21,7 @@ export interface MetadataState {
     };
     state: EditorState;
   };
-<<<<<<< HEAD
   originatingApp?: string;
-=======
-  originatingApp: string | undefined;
->>>>>>> global data persistence for vis builder
 }
 
 const initialState: MetadataState = {

--- a/src/plugins/vis_builder/public/application/utils/state_management/metadata_slice.ts
+++ b/src/plugins/vis_builder/public/application/utils/state_management/metadata_slice.ts
@@ -21,7 +21,11 @@ export interface MetadataState {
     };
     state: EditorState;
   };
+<<<<<<< HEAD
   originatingApp?: string;
+=======
+  originatingApp: string | undefined;
+>>>>>>> global data persistence for vis builder
 }
 
 const initialState: MetadataState = {

--- a/src/plugins/vis_builder/public/application/utils/state_management/metadata_slice.ts
+++ b/src/plugins/vis_builder/public/application/utils/state_management/metadata_slice.ts
@@ -21,6 +21,7 @@ export interface MetadataState {
     };
     state: EditorState;
   };
+  originatingApp: string | undefined;
 }
 
 const initialState: MetadataState = {
@@ -28,6 +29,7 @@ const initialState: MetadataState = {
     validity: {},
     state: 'loading',
   },
+  originatingApp: undefined,
 };
 
 export const getPreloadedState = async ({
@@ -50,6 +52,9 @@ export const slice = createSlice({
     setEditorState: (state, action: PayloadAction<{ state: EditorState }>) => {
       state.editor.state = action.payload.state;
     },
+    setOriginatingApp: (state, action: PayloadAction<{ state: string | undefined }>) => {
+      state.originatingApp = action.payload.state;
+    },
     setState: (_state, action: PayloadAction<MetadataState>) => {
       return action.payload;
     },
@@ -57,4 +62,4 @@ export const slice = createSlice({
 });
 
 export const { reducer } = slice;
-export const { setValidity, setEditorState, setState } = slice.actions;
+export const { setValidity, setEditorState, setOriginatingApp, setState } = slice.actions;

--- a/src/plugins/vis_builder/public/application/utils/state_management/metadata_slice.ts
+++ b/src/plugins/vis_builder/public/application/utils/state_management/metadata_slice.ts
@@ -35,8 +35,14 @@ const initialState: MetadataState = {
 export const getPreloadedState = async ({
   types,
   data,
+  embeddable,
+  scopedHistory,
 }: VisBuilderServices): Promise<MetadataState> => {
-  const preloadedState = { ...initialState };
+  const { originatingApp } =
+    embeddable
+      .getStateTransfer(scopedHistory)
+      .getIncomingEditorState({ keysToRemoveAfterFetch: ['id', 'input'] }) || {};
+  const preloadedState = { ...initialState, originatingApp };
 
   return preloadedState;
 };

--- a/src/plugins/vis_builder/public/application/utils/state_management/metadata_slice.ts
+++ b/src/plugins/vis_builder/public/application/utils/state_management/metadata_slice.ts
@@ -21,7 +21,7 @@ export interface MetadataState {
     };
     state: EditorState;
   };
-  originatingApp: string | undefined;
+  originatingApp?: string;
 }
 
 const initialState: MetadataState = {
@@ -52,7 +52,7 @@ export const slice = createSlice({
     setEditorState: (state, action: PayloadAction<{ state: EditorState }>) => {
       state.editor.state = action.payload.state;
     },
-    setOriginatingApp: (state, action: PayloadAction<{ state: string | undefined }>) => {
+    setOriginatingApp: (state, action: PayloadAction<{ state?: string }>) => {
       state.originatingApp = action.payload.state;
     },
     setState: (_state, action: PayloadAction<MetadataState>) => {

--- a/src/plugins/vis_builder/public/application/utils/state_management/store.ts
+++ b/src/plugins/vis_builder/public/application/utils/state_management/store.ts
@@ -6,7 +6,7 @@
 import { combineReducers, configureStore, PreloadedState } from '@reduxjs/toolkit';
 import { reducer as styleReducer } from './style_slice';
 import { reducer as visualizationReducer } from './visualization_slice';
-import { reducer as metadataReducer } from './metadata_slice';
+import { reducer as metadataReducer, setOriginatingApp } from './metadata_slice';
 import { VisBuilderServices } from '../../..';
 import { getPreloadedState } from './preload';
 import { setEditorState } from './metadata_slice';
@@ -25,6 +25,10 @@ export const configurePreloadedStore = (preloadedState: PreloadedState<RootState
 };
 
 export const getPreloadedStore = async (services: VisBuilderServices) => {
+  const { originatingApp } =
+    services.embeddable
+      .getStateTransfer(services.scopedHistory)
+      .getIncomingEditorState({ keysToRemoveAfterFetch: ['id', 'input'] }) || {};
   const preloadedState = await getPreloadedState(services);
   const store = configurePreloadedStore(preloadedState);
 
@@ -34,6 +38,7 @@ export const getPreloadedStore = async (services: VisBuilderServices) => {
     style: styleState,
   };
   let previousMetadata = metadataState;
+  store.dispatch(setOriginatingApp({ state: originatingApp }));
 
   // Listen to changes
   const handleChange = () => {

--- a/src/plugins/vis_builder/public/application/utils/state_management/store.ts
+++ b/src/plugins/vis_builder/public/application/utils/state_management/store.ts
@@ -10,6 +10,7 @@ import { reducer as metadataReducer, setOriginatingApp } from './metadata_slice'
 import { VisBuilderServices } from '../../..';
 import { getPreloadedState } from './preload';
 import { setEditorState } from './metadata_slice';
+import { EventEmitter } from 'stream';
 
 const rootReducer = combineReducers({
   style: styleReducer,

--- a/src/plugins/vis_builder/public/application/utils/state_management/store.ts
+++ b/src/plugins/vis_builder/public/application/utils/state_management/store.ts
@@ -6,7 +6,7 @@
 import { combineReducers, configureStore, PreloadedState } from '@reduxjs/toolkit';
 import { reducer as styleReducer } from './style_slice';
 import { reducer as visualizationReducer } from './visualization_slice';
-import { reducer as metadataReducer, setOriginatingApp } from './metadata_slice';
+import { reducer as metadataReducer } from './metadata_slice';
 import { VisBuilderServices } from '../../..';
 import { getPreloadedState } from './preload';
 import { setEditorState } from './metadata_slice';
@@ -25,10 +25,6 @@ export const configurePreloadedStore = (preloadedState: PreloadedState<RootState
 };
 
 export const getPreloadedStore = async (services: VisBuilderServices) => {
-  const { originatingApp } =
-    services.embeddable
-      .getStateTransfer(services.scopedHistory)
-      .getIncomingEditorState({ keysToRemoveAfterFetch: ['id', 'input'] }) || {};
   const preloadedState = await getPreloadedState(services);
   const store = configurePreloadedStore(preloadedState);
 
@@ -38,7 +34,6 @@ export const getPreloadedStore = async (services: VisBuilderServices) => {
     style: styleState,
   };
   let previousMetadata = metadataState;
-  store.dispatch(setOriginatingApp({ state: originatingApp }));
 
   // Listen to changes
   const handleChange = () => {

--- a/src/plugins/vis_builder/public/application/utils/use/use_saved_vis_builder_vis.ts
+++ b/src/plugins/vis_builder/public/application/utils/use/use_saved_vis_builder_vis.ts
@@ -24,10 +24,11 @@ import {
 import { useOpenSearchDashboards } from '../../../../../opensearch_dashboards_react/public';
 import { setEditorState } from '../state_management/metadata_slice';
 import { validateVisBuilderState } from '../vis_builder_state_validation';
+import EventEmitter from 'events';
 
 // This function can be used when instantiating a saved vis or creating a new one
 // using url parameters, embedding and destroying it in DOM
-export const useSavedVisBuilderVis = (visualizationIdFromUrl: string | undefined) => {
+export const useSavedVisBuilderVis = (eventEmitter: EventEmitter, visualizationIdFromUrl: string | undefined) => {
   const { services } = useOpenSearchDashboards<VisBuilderServices>();
   const [savedVisState, setSavedVisState] = useState<SavedObject | undefined>(undefined);
   const dispatch = useTypedDispatch();
@@ -116,7 +117,7 @@ export const useSavedVisBuilderVis = (visualizationIdFromUrl: string | undefined
     };
 
     loadSavedVisBuilderVis();
-  }, [dispatch, services, visualizationIdFromUrl]);
+  }, [eventEmitter,dispatch, services, visualizationIdFromUrl]);
 
   return savedVisState;
 };

--- a/src/plugins/vis_builder/public/application/utils/use/use_saved_vis_builder_vis.ts
+++ b/src/plugins/vis_builder/public/application/utils/use/use_saved_vis_builder_vis.ts
@@ -28,7 +28,7 @@ import EventEmitter from 'events';
 
 // This function can be used when instantiating a saved vis or creating a new one
 // using url parameters, embedding and destroying it in DOM
-export const useSavedVisBuilderVis = (eventEmitter: EventEmitter, visualizationIdFromUrl: string | undefined) => {
+export const useSavedVisBuilderVis = (visualizationIdFromUrl: string | undefined) => {
   const { services } = useOpenSearchDashboards<VisBuilderServices>();
   const [savedVisState, setSavedVisState] = useState<SavedObject | undefined>(undefined);
   const dispatch = useTypedDispatch();
@@ -117,7 +117,7 @@ export const useSavedVisBuilderVis = (eventEmitter: EventEmitter, visualizationI
     };
 
     loadSavedVisBuilderVis();
-  }, [eventEmitter,dispatch, services, visualizationIdFromUrl]);
+  }, [dispatch, services, visualizationIdFromUrl]);
 
   return savedVisState;
 };

--- a/src/plugins/vis_builder/public/application/utils/use/use_vis_builder_app_state.tsx
+++ b/src/plugins/vis_builder/public/application/utils/use/use_vis_builder_app_state.tsx
@@ -67,8 +67,12 @@ export const useVisBuilderAppState = (
   //const [hasUnappliedChanges, setHasUnappliedChanges] = useState(false);
   const [appState, setAppState] = useState<VisBuilderAppStateContainer | null>(null);
   const visualizationState = useTypedSelector(state => state.visualization)
+  //const [visualizationState, setVisualizationState] = useState()
   //const styleState = useTypedSelector((state)=>state.style)
   const dispatch = useTypedDispatch();
+  /*useEffect(() => {
+
+  }, visualizationState)*/
   
   useEffect(() => {
     if (instance && rootState) {
@@ -89,6 +93,9 @@ export const useVisBuilderAppState = (
           const currentStates = visBuilderEditorState(instance, services, rootState)
           // it is important to update vis state with fresh data
           console.log("instance", instance)
+          console.log("root state", rootState)
+
+          
           console.log("visualizationstate", visualizationState)
           console.log("before", stateContainer.getState().visualizationState)
           stateContainer.transitions.updateVisState(visBuilderEditorState(instance, services, rootState).visualizationState);
@@ -146,12 +153,12 @@ const migrateLegacyQuery = (query: Query | { [key: string]: any } | string): Que
       
       if (!isEqual(stateContainer.getState().visualizationState, stateDefaults.visualizationState)) {
         const visualizationState = stateContainer.getState().visualizationState;
-        dispatch(setVisualizationState(visualizationState))
+        //dispatch(setVisualizationState(visualizationState))
       } 
 
       if(!isEqual(stateContainer.getState().styleState, stateDefaults.styleState)){
         const styleState = stateContainer.getState().styleState;
-        dispatch(setStyleState(styleState))
+        //dispatch(setStyleState(styleState))
       }
       
       setAppState(stateContainer);
@@ -164,7 +171,7 @@ const migrateLegacyQuery = (query: Query | { [key: string]: any } | string): Que
         stopSyncingAppFilters();
       };
     }
-  }, [eventEmitter, instance, services ]);
+  }, [eventEmitter, instance, services, visualizationState ]);
 
   return appState;
 };

--- a/src/plugins/vis_builder/public/application/utils/use/use_vis_builder_app_state.tsx
+++ b/src/plugins/vis_builder/public/application/utils/use/use_vis_builder_app_state.tsx
@@ -42,7 +42,7 @@ import {
   VisBuilderContainer,
   VisBuilderVisInstance,
 } from '../../../types';
-import { visStateToEditorState } from '../../utils';
+import { visBuilderStateToEditorState } from '../get_vis_builder_editor_state';
 import { createVisBuilderAppState } from '../create_vis_builder_app_state';
 import { VisualizeConstants } from '../../visualize_constants';
 import { SavedObject } from '../../../../../saved_objects/public';
@@ -61,7 +61,7 @@ export const useVisBuilderAppState = (
 
   useEffect(() => {
     if (instance) {
-      const stateDefaults = visStateToEditorState(instance, services);
+      const stateDefaults = visBuilderStateToEditorState(instance, services);
       const { stateContainer, stopStateSync } = createVisBuilderAppState({
         stateDefaults,
         osdUrlStateStorage: services.osdUrlStateStorage,
@@ -70,7 +70,7 @@ export const useVisBuilderAppState = (
       const onDirtyStateChange = ({ isDirty }: { isDirty: boolean }) => {
         if (!isDirty) {
           // it is important to update vis state with fresh data
-          stateContainer.transitions.updateVisState(visStateToEditorState(instance, services).vis);
+          stateContainer.transitions.updateVisState(visBuilderStateToEditorState(instance, services).vis);
         }
         setHasUnappliedChanges(isDirty);
       };

--- a/src/plugins/vis_builder/public/application/utils/use/use_vis_builder_app_state.tsx
+++ b/src/plugins/vis_builder/public/application/utils/use/use_vis_builder_app_state.tsx
@@ -38,34 +38,33 @@ import { MarkdownSimple, toMountPoint } from '../../../../../opensearch_dashboar
 import { migrateLegacyQuery } from '../migrate_legacy_query';
 import { opensearchFilters, connectToQueryState } from '../../../../../data/public';
 import {
-  VisualizeServices,
-  VisualizeAppStateContainer,
-  VisualizeEditorVisInstance,
-} from '../../types';
-import { visStateToEditorState } from '../utils';
-import { createVisualizeAppState } from '../create_visualize_app_state';
+    VisBuilderServices,
+  VisBuilderContainer,
+  VisBuilderVisInstance,
+} from '../../../types';
+import { visStateToEditorState } from '../../utils';
+import { createVisBuilderAppState } from '../create_vis_builder_app_state';
 import { VisualizeConstants } from '../../visualize_constants';
+import { SavedObject } from '../../../../../saved_objects/public';
+
 /**
  * This effect is responsible for instantiating the visualize app state container,
  * which is in sync with "_a" url param
  */
-export const useVisualizeAppState = (
-  services: VisualizeServices,
+export const useVisBuilderAppState = (
+  services: VisBuilderServices,
   eventEmitter: EventEmitter,
-  instance?: VisualizeEditorVisInstance
+  instance?: SavedObject
 ) => {
-  const [hasUnappliedChanges, setHasUnappliedChangpes] = useState(false);
+  const [hasUnappliedChanges, setHasUnappliedChanges] = useState(false);
   const [appState, setAppState] = useState<VisualizeAppStateContainer | null>(null);
 
   useEffect(() => {
     if (instance) {
       const stateDefaults = visStateToEditorState(instance, services);
-      console.log("visualize vis state", stateDefaults)
-      const byValue = !('savedVis' in instance);
-      const { stateContainer, stopStateSync } = createVisualizeAppState({
+      const { stateContainer, stopStateSync } = createVisBuilderAppState({
         stateDefaults,
         osdUrlStateStorage: services.osdUrlStateStorage,
-        byValue,
       });
 
       const onDirtyStateChange = ({ isDirty }: { isDirty: boolean }) => {

--- a/src/plugins/vis_builder/public/plugin.test.ts
+++ b/src/plugins/vis_builder/public/plugin.test.ts
@@ -28,6 +28,7 @@ describe('VisBuilderPlugin', () => {
       const setupDeps = {
         visualizations: visualizationsPluginMock.createSetupContract(),
         embeddable: embeddablePluginMock.createSetupContract(),
+        data: dataPluginMock.createSetupContract(),
       };
 
       const setup = plugin.setup(coreSetup, setupDeps);

--- a/src/plugins/vis_builder/public/plugin.ts
+++ b/src/plugins/vis_builder/public/plugin.ts
@@ -56,6 +56,8 @@ import {
   withNotifyOnErrors,
 } from '../../opensearch_dashboards_utils/public';
 import { opensearchFilters } from '../../data/public';
+import { useState } from 'react';
+import EventEmitter from 'events';
 
 export class VisBuilderPlugin
   implements
@@ -161,6 +163,7 @@ export class VisBuilderPlugin
         };
 
         // Instantiate the store
+        
         const store = await getPreloadedStore(services);
         const unmount = renderApp(params, services, store);
         

--- a/src/plugins/vis_builder/public/plugin.ts
+++ b/src/plugins/vis_builder/public/plugin.ts
@@ -162,7 +162,7 @@ export class VisBuilderPlugin
         // Instantiate the store
         const store = await getPreloadedStore(services);
         const unmount = renderApp(params, services, store);
-
+        
         // Render the application
         return () => {
           unlistenParentHistory();

--- a/src/plugins/vis_builder/public/plugin.ts
+++ b/src/plugins/vis_builder/public/plugin.ts
@@ -134,10 +134,11 @@ export class VisBuilderPlugin
 
         // dispatch synthetic hash change event to update hash history objects
         // this is necessary because hash updates triggered by using popState won't trigger this event naturally.
-        const unlistenParentHistory = this.currentHistory.listen(() => {
+        const unlistenParentHistory = params.history.listen(() => {
           window.dispatchEvent(new HashChangeEvent('hashchange'));
         });
 
+        // Register Default Visualizations
         const services: VisBuilderServices = {
           ...coreStart,
           scopedHistory: this.currentHistory,

--- a/src/plugins/vis_builder/public/plugin_services.ts
+++ b/src/plugins/vis_builder/public/plugin_services.ts
@@ -37,3 +37,7 @@ export const [getTimeFilter, setTimeFilter] = createGetterSetter<TimefilterContr
 export const [getTypeService, setTypeService] = createGetterSetter<TypeServiceStart>('TypeService');
 
 export const [getUISettings, setUISettings] = createGetterSetter<IUiSettingsClient>('UISettings');
+
+export const [getQueryService, setQueryService] = createGetterSetter<
+  DataPublicPluginStart['query']
+>('Query');

--- a/src/plugins/vis_builder/public/types.ts
+++ b/src/plugins/vis_builder/public/types.ts
@@ -27,6 +27,25 @@ export interface VisBuilderStart extends TypeServiceStart {
 export interface EventEmitterProp {
   eventEmitter: EventEmitter
 }
+
+
+
+export interface LeftNavProps {
+  appState: VisBuilderAppStateContainer;
+}
+
+export interface DataSourceSelectProps {
+  appState: VisBuilderAppStateContainer;
+}
+
+export interface DataTabProps {
+  appState: VisBuilderAppStateContainer;
+}
+
+export interface ConfigPanelProps {
+  appState: VisBuilderAppStateContainer;
+}
+
 export interface VisBuilderPluginSetupDependencies {
   embeddable: EmbeddableSetup;
   visualizations: VisualizationsSetup;
@@ -54,11 +73,6 @@ export interface VisBuilderServices extends CoreStart {
   embeddable: EmbeddableStart;
   scopedHistory: ScopedHistory;
   osdUrlStateStorage: IOsdUrlStateStorage;
-<<<<<<< HEAD
-=======
-  setActiveUrl: (newUrl: string) => void;
-  restorePreviousUrl: () => void;
->>>>>>> global data persistence for vis builder
   dashboard: DashboardStart;
 }
 

--- a/src/plugins/vis_builder/public/types.ts
+++ b/src/plugins/vis_builder/public/types.ts
@@ -49,6 +49,11 @@ export interface VisBuilderServices extends CoreStart {
   embeddable: EmbeddableStart;
   scopedHistory: ScopedHistory;
   osdUrlStateStorage: IOsdUrlStateStorage;
+<<<<<<< HEAD
+=======
+  setActiveUrl: (newUrl: string) => void;
+  restorePreviousUrl: () => void;
+>>>>>>> global data persistence for vis builder
   dashboard: DashboardStart;
 }
 

--- a/src/plugins/vis_builder/public/types.ts
+++ b/src/plugins/vis_builder/public/types.ts
@@ -10,18 +10,23 @@ import { DashboardStart } from '../../dashboard/public';
 import { VisualizationsSetup } from '../../visualizations/public';
 import { ExpressionsStart } from '../../expressions/public';
 import { NavigationPublicPluginStart } from '../../navigation/public';
-import { DataPublicPluginStart } from '../../data/public';
+import { DataPublicPluginStart, Filter, Query } from '../../data/public';
 import { TypeServiceSetup, TypeServiceStart } from './services/type_service';
 import { SavedObjectLoader } from '../../saved_objects/public';
 import { AppMountParameters, CoreStart, ToastsStart, ScopedHistory } from '../../../core/public';
-import { IOsdUrlStateStorage } from '../../opensearch_dashboards_utils/public';
+import { IOsdUrlStateStorage, ReduxLikeStateContainer } from '../../opensearch_dashboards_utils/public';
 import { DataPublicPluginSetup } from '../../data/public';
+import { StyleState, VisualizationState } from './application/utils/state_management';
+import { EventEmitter } from 'stream';
 
 export type VisBuilderSetup = TypeServiceSetup;
 export interface VisBuilderStart extends TypeServiceStart {
   savedVisBuilderLoader: SavedObjectLoader;
 }
 
+export interface EventEmitterProp {
+  eventEmitter: EventEmitter
+}
 export interface VisBuilderPluginSetupDependencies {
   embeddable: EmbeddableSetup;
   visualizations: VisualizationsSetup;
@@ -67,3 +72,27 @@ export interface ISavedVis {
 }
 
 export interface VisBuilderVisSavedObject extends SavedObject, ISavedVis {}
+
+export type VisBuilderAppStateContainer = ReduxLikeStateContainer<
+  VisBuilderAppState,
+  VisBuilderAppStateTransitions
+>;
+export interface VisBuilderAppState {
+  filters: Filter[];
+  uiState?: Record<string, unknown>;
+  visualizationState: VisualizationState;
+  styleState: StyleState;
+  query: Query;
+  savedQuery?: string;
+}
+export interface VisBuilderAppStateTransitions {
+  set: (
+    state: VisBuilderAppState
+  ) => <T extends keyof VisBuilderAppState>(
+    prop: T,
+    value: VisBuilderAppState[T]
+  ) => VisBuilderAppState;
+  updateVisState: (state: VisBuilderAppState) => (vis: VisualizationState) => VisBuilderAppState;
+  updateStyleState: (state: VisBuilderAppState) => (style: StyleState) => VisBuilderAppState;
+  updateSavedQuery: (state: VisBuilderAppState) => (savedQueryId?: string) => VisBuilderAppState;
+}

--- a/src/plugins/vis_builder/public/types.ts
+++ b/src/plugins/vis_builder/public/types.ts
@@ -15,7 +15,6 @@ import { TypeServiceSetup, TypeServiceStart } from './services/type_service';
 import { SavedObjectLoader } from '../../saved_objects/public';
 import { AppMountParameters, CoreStart, ToastsStart, ScopedHistory } from '../../../core/public';
 import { IOsdUrlStateStorage } from '../../opensearch_dashboards_utils/public';
-import { UrlForwardingSetup } from '../../url_forwarding/public';
 import { DataPublicPluginSetup } from '../../data/public';
 
 export type VisBuilderSetup = TypeServiceSetup;

--- a/src/plugins/vis_builder/public/types.ts
+++ b/src/plugins/vis_builder/public/types.ts
@@ -14,6 +14,9 @@ import { DataPublicPluginStart } from '../../data/public';
 import { TypeServiceSetup, TypeServiceStart } from './services/type_service';
 import { SavedObjectLoader } from '../../saved_objects/public';
 import { AppMountParameters, CoreStart, ToastsStart, ScopedHistory } from '../../../core/public';
+import { IOsdUrlStateStorage } from '../../opensearch_dashboards_utils/public';
+import { UrlForwardingSetup } from '../../url_forwarding/public';
+import { DataPublicPluginSetup } from '../../data/public';
 
 export type VisBuilderSetup = TypeServiceSetup;
 export interface VisBuilderStart extends TypeServiceStart {
@@ -23,6 +26,7 @@ export interface VisBuilderStart extends TypeServiceStart {
 export interface VisBuilderPluginSetupDependencies {
   embeddable: EmbeddableSetup;
   visualizations: VisualizationsSetup;
+  data: DataPublicPluginSetup;
 }
 export interface VisBuilderPluginStartDependencies {
   embeddable: EmbeddableStart;
@@ -45,6 +49,10 @@ export interface VisBuilderServices extends CoreStart {
   history: History;
   embeddable: EmbeddableStart;
   scopedHistory: ScopedHistory;
+  osdUrlStateStorage: IOsdUrlStateStorage;
+  setActiveUrl: (newUrl: string) => void;
+  restorePreviousUrl: () => void;
+  dashboard: DashboardStart;
 }
 
 export interface ISavedVis {

--- a/src/plugins/vis_builder/public/types.ts
+++ b/src/plugins/vis_builder/public/types.ts
@@ -50,8 +50,6 @@ export interface VisBuilderServices extends CoreStart {
   embeddable: EmbeddableStart;
   scopedHistory: ScopedHistory;
   osdUrlStateStorage: IOsdUrlStateStorage;
-  setActiveUrl: (newUrl: string) => void;
-  restorePreviousUrl: () => void;
   dashboard: DashboardStart;
 }
 

--- a/src/plugins/vis_default_editor/public/components/sidebar/controls.tsx
+++ b/src/plugins/vis_default_editor/public/components/sidebar/controls.tsx
@@ -122,7 +122,7 @@ function DefaultEditorControls({
           </EuiFlexItem>
         </EuiFlexGroup>
       )}
-      {enableAutoApply && (
+      {(
         <EuiToolTip
           title={
             autoApplyEnabled

--- a/src/plugins/visualize/public/application/components/visualize_editor.tsx
+++ b/src/plugins/visualize/public/application/components/visualize_editor.tsx
@@ -53,18 +53,21 @@ export const VisualizeEditor = ({ onAppLeave }: VisualizeAppProps) => {
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(!visualizationIdFromUrl);
 
   const isChromeVisible = useChromeVisibility(services.chrome);
+  
   const { savedVisInstance, visEditorRef, visEditorController } = useSavedVisInstance(
     services,
     eventEmitter,
     isChromeVisible,
     visualizationIdFromUrl
   );
-  console.log("visualize instance before it pass to get appstate", savedVisInstance)
+  console.log("savedVisInstance", savedVisInstance)
+  //console.log("visualize instance before it pass to get appstate", savedVisInstance)
   const { appState, hasUnappliedChanges } = useVisualizeAppState(
     services,
     eventEmitter,
     savedVisInstance
   );
+  console.log("visualize appState", appState?.getState())
   const { isEmbeddableRendered, currentAppState } = useEditorUpdates(
     services,
     eventEmitter,

--- a/src/plugins/visualize/public/application/components/visualize_editor.tsx
+++ b/src/plugins/visualize/public/application/components/visualize_editor.tsx
@@ -59,6 +59,7 @@ export const VisualizeEditor = ({ onAppLeave }: VisualizeAppProps) => {
     isChromeVisible,
     visualizationIdFromUrl
   );
+  console.log("visualize instance before it pass to get appstate", savedVisInstance)
   const { appState, hasUnappliedChanges } = useVisualizeAppState(
     services,
     eventEmitter,

--- a/src/plugins/visualize/public/application/utils/use/use_visualize_app_state.tsx
+++ b/src/plugins/visualize/public/application/utils/use/use_visualize_app_state.tsx
@@ -60,7 +60,8 @@ export const useVisualizeAppState = (
   useEffect(() => {
     if (instance) {
       const stateDefaults = visStateToEditorState(instance, services);
-      console.log("visualize vis state", stateDefaults)
+    
+      console.log("visualize state defaults", stateDefaults)
       const byValue = !('savedVis' in instance);
       const { stateContainer, stopStateSync } = createVisualizeAppState({
         stateDefaults,

--- a/src/plugins/visualize/public/application/utils/use/use_visualize_app_state.tsx
+++ b/src/plugins/visualize/public/application/utils/use/use_visualize_app_state.tsx
@@ -54,11 +54,12 @@ export const useVisualizeAppState = (
   eventEmitter: EventEmitter,
   instance?: VisualizeEditorVisInstance
 ) => {
-  const [hasUnappliedChanges, setHasUnappliedChangpes] = useState(false);
+  const [hasUnappliedChanges, setHasUnappliedChanges] = useState(false);
   const [appState, setAppState] = useState<VisualizeAppStateContainer | null>(null);
 
   useEffect(() => {
     if (instance) {
+      console.log("visualize instance", instance)
       const stateDefaults = visStateToEditorState(instance, services);
     
       console.log("visualize state defaults", stateDefaults)
@@ -72,6 +73,7 @@ export const useVisualizeAppState = (
       const onDirtyStateChange = ({ isDirty }: { isDirty: boolean }) => {
         if (!isDirty) {
           // it is important to update vis state with fresh data
+          console.log("instance", instance)
           stateContainer.transitions.updateVisState(visStateToEditorState(instance, services).vis);
         }
         setHasUnappliedChanges(isDirty);

--- a/yarn.lock
+++ b/yarn.lock
@@ -14995,6 +14995,11 @@ redent@^3.0.0:
     indent-string "^4.0.0"
     strip-indent "^3.0.0"
 
+redux-devtools-extension@^2.13.9:
+  version "2.13.9"
+  resolved "https://registry.yarnpkg.com/redux-devtools-extension/-/redux-devtools-extension-2.13.9.tgz#6b764e8028b507adcb75a1cae790f71e6be08ae7"
+  integrity sha512-cNJ8Q/EtjhQaZ71c8I9+BPySIBVEKssbPpskBfsXqb8HJ002A3KRVHfeRzwRo6mGPqsm7XuHTqNSNeS1Khig0A==
+
 redux-thunk@^2.3.0, redux-thunk@^2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.4.1.tgz#0dd8042cf47868f4b29699941de03c9301a75714"


### PR DESCRIPTION
### Description
This draft PR attempts to follow the current app persistence implementation in dashboards. Use state container, state storage and state sync utils. Only get app filter and query persistence working currently. For other visualization and style data persistence, it might not be ideal following the implementations from other plugins, based on the structure of vis builder.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
  - [ ] `yarn test:ftr`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 